### PR TITLE
feat: implement custom user config file

### DIFF
--- a/src/ares/config_parser.py
+++ b/src/ares/config_parser.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from os import path
+
+import yaml
+from src.ares.consts import CONFIG_FILE
+
+
+@dataclass
+class ConfigParser:
+    """Process user and internal config.
+
+    Internal config is used by default, optional user config overrides default values
+
+    Attributes
+    ----------
+    ares_config_location : str
+        Path to internal Ares config.yml file.
+    user_config_location : bool
+        Path to user config.yml file.
+    """
+    ares_config_location: str
+    user_config_location: str
+
+    def parse(self) -> dict:
+        """
+        Handle internal and user config
+
+        Returns
+        -------
+        Dict :
+            Internal parsed config.yml by default, or the merged internal and
+            users config files.
+        """
+        internal_config_path: str = path.join(self.ares_config_location, CONFIG_FILE)
+        user_config_path: str = path.join(self.user_config_location, CONFIG_FILE)
+        if path.isfile(internal_config_path):
+            with open(internal_config_path, "r") as config_file:
+                internal_config: dict = yaml.safe_load(config_file)
+        else:
+            raise Exception("Internal Ares config.yml file is missing")
+
+        if path.isfile(user_config_path):
+            with open(user_config_path, "r") as config_file:
+                user_config: dict = yaml.safe_load(config_file)
+        # if no user config, fine to return internal_config here
+        else:
+            return internal_config
+
+        # there is a user config and internal config, sort out the differences
+        return self._merge_config_files(internal_config, user_config)
+
+    @staticmethod
+    def _merge_config_files(internal_config: dict, user_config: dict) -> dict:
+        """
+        Merge internal and user config files so we are left with just one.
+
+        Start off with the internal_config, then override any matching keys
+        in the user_config. Types the user pass in need to be checked.
+
+        Parameters
+        ----------
+        internal_config :
+            Internal config dictionary already parsed from the original yaml file.
+        user_config :
+            User config dictionary already parsed from the original yaml file.
+
+        Returns
+        -------
+        Dict :
+            A single config dictionary where user values override default values.
+        """
+        config: dict = internal_config.copy()
+        # iterate through internal config, and search for matching values in user's config
+        for k, v in internal_config.items():
+            value_type = type(v)
+            if value_type == dict and k in user_config:
+                config[k] = internal_config[k] | user_config[k]
+
+            elif k in user_config and type(user_config[k]) == value_type:
+                config[k] = user_config[k]
+
+        return config

--- a/src/ares/config_parser.py
+++ b/src/ares/config_parser.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from os import path
 
 import yaml
+
 from src.ares.consts import CONFIG_FILE
 
 
@@ -18,6 +19,7 @@ class ConfigParser:
     user_config_location : bool
         Path to user config.yml file.
     """
+
     ares_config_location: str
     user_config_location: str
 
@@ -70,7 +72,7 @@ class ConfigParser:
             A single config dictionary where user values override default values.
         """
         config: dict = internal_config.copy()
-        # iterate through internal config, and search for matching values in user's config
+        # iterate through internal config, and search for matching values in user config
         for k, v in internal_config.items():
             value_type = type(v)
             if value_type == dict and k in user_config:

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -7,6 +7,8 @@ from os import getcwd, path
 from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
 import yaml
+
+from ares.config_parser import ConfigParser
 from consts import (
     ADD_SHADES_ON_FRAME,
     ALL_STRUCTURES,
@@ -74,9 +76,14 @@ class AresBot(CustomBotAI):
         # use this Dict when compiling
         # self.config: Dict = CONFIG
         # otherwise we use the config.yml file
-        __location__ = path.realpath(path.join(getcwd(), path.dirname(__file__)))
-        with open(path.join(__location__, CONFIG_FILE), "r") as config_file:
-            self.config = yaml.safe_load(config_file)
+        __ares_config_location__: str = path.realpath(
+            path.join(getcwd(), path.dirname(__file__))
+        )
+        __user_config_location__: str = path.abspath(".")
+        config_parser: ConfigParser = ConfigParser(
+            __ares_config_location__, __user_config_location__
+        )
+        self.config = config_parser.parse()
 
         self.game_step_override: Optional[int] = game_step_override
         self.unit_tag_dict: Dict[int, Unit] = {}

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -6,15 +6,11 @@ from collections import defaultdict
 from os import getcwd, path
 from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
-import yaml
-
-from ares.config_parser import ConfigParser
 from consts import (
     ADD_SHADES_ON_FRAME,
     ALL_STRUCTURES,
     BANNED_PHRASES,
     CHAT_DEBUG,
-    CONFIG_FILE,
     DEBUG,
     DEBUG_GAME_STEP,
     DEBUG_OPTIONS,
@@ -51,6 +47,7 @@ from sc2.units import Units
 
 from ares.behavior_exectioner import BehaviorExecutioner
 from ares.behaviors.behavior import Behavior
+from ares.config_parser import ConfigParser
 
 
 class AresBot(CustomBotAI):


### PR DESCRIPTION
Closes #14 

Allows users to add a `config.yml` in their root directory, which then overrides values in `ares`'s config file

This is a prerequisite to #18 which will be worked on next.