### PR TITLE
revert: "build: prevent dist and build directories when compiling cython"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ line-profiler = "^4.0.3"
 [build-system]
 requires = ["poetry-core", "Cython", "numpy", "setuptools"]
 build-backend = "poetry.core.masonry.api"
-build = { exclude = ["dist/*", "build/*"] }
 
 [tool.poetry.build]
 generate-setup-file = false


### PR DESCRIPTION
Reverts AresSC2/ares-sc2#58