### PR TITLE
fix: placement formation add gaps to help prevent unit block

### DIFF
--- a/src/ares/cython_extensions/flood_fill.pyx
+++ b/src/ares/cython_extensions/flood_fill.pyx
@@ -20,10 +20,6 @@ cpdef set flood_fill_grid(
     if not terrain_height:
         return filled_points
 
-    # if pathing_value != 1:
-    #     print("r3r3r")
-    #     return filled_points
-
     grid_flood_fill(start_point, terrain_grid, pathing_grid, terrain_height, filled_points, start_point, max_distance, choke_points)
     return filled_points
 


### PR DESCRIPTION
Not a full solution to blocking own units, but fixes for maps I'd noticed this issue on. Does provide an extra escape route especially in main bases.