### PR TITLE
fix: remove unit tag from squads when assigning new role

### DIFF
--- a/docs/tutorials/tips_and_tricks.md
+++ b/docs/tutorials/tips_and_tricks.md
@@ -44,3 +44,6 @@ from sc2.unit import Unit
 unit: Unit = self.units[0]
 self.mediator.remove_tag_from_squads(tag=unit.tag)
 ```
+
+Note if you're using the `ares` role system, when assigning a unit a new role,
+units are removed from squads automatically.

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -1866,6 +1866,8 @@ class ManagerMediator(IManagerMediator):
             Tag of the unit to be assigned.
         role : UnitRole
             What role the unit should have.
+        remove_from_squad : bool (default = True)
+            Attempt to remove this unit from squad bookkeeping.
 
         Returns
         ----------

--- a/src/ares/managers/squad_manager.py
+++ b/src/ares/managers/squad_manager.py
@@ -107,9 +107,9 @@ class SquadManager(Manager, IManagerMediator):
             ManagerRequestType.GET_POSITION_OF_MAIN_SQUAD: lambda kwargs: (
                 self._get_position_of_main_squad(**kwargs)
             ),
-            ManagerRequestType.GET_SQUADS: lambda kwargs: (self._get_squads(**kwargs)),
+            ManagerRequestType.GET_SQUADS: lambda kwargs: self._get_squads(**kwargs),
             ManagerRequestType.REMOVE_TAG_FROM_SQUADS: lambda kwargs: self.remove_tag(
-                kwargs["tag"]
+                **kwargs
             ),
         }
 
@@ -173,6 +173,8 @@ class SquadManager(Manager, IManagerMediator):
 
     def remove_tag(self, tag: int) -> None:
         if tag in self._assigned_unit_tags:
+            self._assigned_unit_tags.remove(tag)
+
             found_squad: bool = False
             squad_id_to_remove_from = ""
             role: UnitRole = UnitRole.ATTACKING
@@ -428,9 +430,6 @@ class SquadManager(Manager, IManagerMediator):
         """
         if squad_id not in self._squads_dict[role]:
             return
-
-        if tag in self._assigned_unit_tags:
-            self._assigned_unit_tags.remove(tag)
 
         if tag in self._squads_dict[role][squad_id][self.TAGS]:
             self._squads_dict[role][squad_id][self.TAGS].remove(tag)

--- a/src/ares/managers/unit_role_manager.py
+++ b/src/ares/managers/unit_role_manager.py
@@ -164,7 +164,9 @@ class UnitRoleManager(Manager, IManagerMediator):
             if unit.type_id == self.ai.worker_type:
                 self.assign_role(unit.tag, UnitRole.GATHERING)
 
-    def assign_role(self, tag: int, role: UnitRole) -> None:
+    def assign_role(
+        self, tag: int, role: UnitRole, remove_from_squad: bool = True
+    ) -> None:
         """Assign a unit a role.
 
         Parameters
@@ -173,6 +175,10 @@ class UnitRoleManager(Manager, IManagerMediator):
             Tag of the unit to be assigned.
         role :
             What role the unit should have.
+        remove_from_squad :
+            Search for this unit in UnitSquads and remove it.
+            Default=True prevents unexpected bugs when using
+            UnitSquads
 
         Returns
         -------
@@ -181,6 +187,8 @@ class UnitRoleManager(Manager, IManagerMediator):
         self.clear_role(tag)
         self.unit_role_dict[role.name].add(tag)
         self.tag_to_role_dict[tag] = role.name
+        if remove_from_squad:
+            self.manager_mediator.remove_tag_from_squads(tag=tag)
 
     def batch_assign_role(
         self, tags: Union[List[int], Set[int]], role: UnitRole


### PR DESCRIPTION
This fix allows units to be reassigned to a `UnitSquad` after previously being unassigned