### PR TITLE
fix: build runner can use reactor

### DIFF
--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -219,11 +219,10 @@ class BuildOrderParser:
         return lambda: BuildOrderStep(
             command=unit_id,
             start_condition=lambda: self.ai.can_afford(unit_id)
-            and self.ai.all_own_units.filter(
-                lambda s: s.type_id in UNIT_TRAINED_FROM[unit_id]
-                and s.build_progress == 1.0
-                and s.is_idle
-            ),
+            and len(self.ai.get_build_structures(
+                UNIT_TRAINED_FROM[unit_id],
+                unit_id,
+            )) > 0,
             # if start condition is True a train order will be issued
             # therefore it will automatically complete the step
             end_condition=lambda: True,

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -219,10 +219,13 @@ class BuildOrderParser:
         return lambda: BuildOrderStep(
             command=unit_id,
             start_condition=lambda: self.ai.can_afford(unit_id)
-            and len(self.ai.get_build_structures(
-                UNIT_TRAINED_FROM[unit_id],
-                unit_id,
-            )) > 0,
+            and len(
+                self.ai.get_build_structures(
+                    UNIT_TRAINED_FROM[unit_id],
+                    unit_id,
+                )
+            )
+            > 0,
             # if start condition is True a train order will be issued
             # therefore it will automatically complete the step
             end_condition=lambda: True,


### PR DESCRIPTION
Reuses `SpawnController`, and correctly checks build from structures in build step.