### PR TITLE
optimization: turn tactical grid off by default

### DIFF
--- a/src/ares/config.yml
+++ b/src/ares/config.yml
@@ -22,7 +22,7 @@ Distances:
 Features:
     # this grid is useful for disruptor balls and maybe some other uses
     # off by default to save computation
-    TacticalGroundGrid: True
+    TacticalGroundGrid: False
 
 Building:
     # how many seconds before giving up on a construction order?


### PR DESCRIPTION
Seems like wasted computation for most bots, authors should turn on if they need it