### PR TITLE
fix(data_manager): update default enemy result value to 2

### DIFF
--- a/src/ares/managers/data_manager.py
+++ b/src/ares/managers/data_manager.py
@@ -253,7 +253,7 @@ class DataManager(Manager, IManagerMediator):
                     RACE: str(self.ai.enemy_race),
                     DURATION: 0,
                     STRATEGY_USED: self.build_cycle[0],
-                    RESULT: 0,
+                    RESULT: 2,
                 }
             ]
 


### PR DESCRIPTION
This ensures first declared build is used if no data yet