### PR TITLE
Fix/"mediator" property def - type hint override error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
       # check-out repo
       - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+        uses: actions/checkout@v4
       # install poetry
       - name: Install poetry
         run: pipx install poetry==1.6.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
       # check-out repo
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       # install poetry
       - name: Install poetry
         run: pipx install poetry
@@ -43,7 +41,7 @@ jobs:
           poetry run make unit-tests-cov-fail
       # add pytest coverage report to PR
       - name: Pytest coverage comment
-        if: ${{ success() && github.event_name == 'pull_request' }}
+        if: ${{ success() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: coverageComment
         uses: MishaKav/pytest-coverage-comment@main
         with:

--- a/src/ares/custom_bot_ai.py
+++ b/src/ares/custom_bot_ai.py
@@ -33,6 +33,7 @@ from ares.consts import (
 )
 from ares.dicts.unit_data import UNIT_DATA
 from ares.dicts.unit_tech_requirement import UNIT_TECH_REQUIREMENT
+from ares.managers.hub import Hub
 from ares.managers.manager_mediator import ManagerMediator
 
 
@@ -45,9 +46,24 @@ class CustomBotAI(BotAI):
     gas_type: UnitID
     unit_tag_dict: dict[int, Unit]
     worker_type: UnitID
-    mediator: ManagerMediator
+    manager_hub: Hub
+    """Hub in charge of handling the Managers"""
     CANT_BUILD_LOCATION_INVALID: int = 44
     _blocked_positions: set[Point2] = set()
+
+    @property
+    def mediator(self) -> ManagerMediator:
+        """Register behavior.
+
+        Shortcut to `self.manager_hub.manager_mediator`
+
+
+        Returns
+        -------
+        ManagerMediator
+
+        """
+        return self.manager_hub.manager_mediator
 
     async def on_step(self, iteration: int):  # pragma: no cover
         """Here because all abstract methods have to be implemented.

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -442,20 +442,6 @@ class AresBot(CustomBotAI):
         """
         self.behavior_executioner.register_behavior(behavior)
 
-    @property
-    def mediator(self) -> ManagerMediator:
-        """Register behavior.
-
-        Shortcut to `self.manager_hub.manager_mediator`
-
-
-        Returns
-        -------
-        ManagerMediator
-
-        """
-        return self.manager_hub.manager_mediator
-
     async def on_end(self, game_result: Result) -> None:
         """Output game info to the log and save data (if enabled)
 

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -68,7 +68,7 @@ class AresBot(CustomBotAI):
     behavior_executioner: BehaviorExecutioner  # executes behaviors on each step
     build_order_runner: BuildOrderRunner  # execute exact build order from config
     cost_dict: Dict[UnitID, Cost]  #: UnitTypeId to cost for faster lookup later
-    manager_hub: Hub  #: Hub in charge of handling the Managers
+
     NYDUSES: set[UnitID] = {UnitID.NYDUSCANAL, UnitID.NYDUSNETWORK}
     UNIT_TYPES_NOT_IN_SLIM: set[UnitID] = {
         UnitID.EGG,


### PR DESCRIPTION
Moved the "mediator" property def to custom_bot_ai.py from main.py to eliminate "mediator" override type hint error.

 "mediator" overrides symbol of same name in class "CustomBotAI"
  "property" is not assignable to "ManagerMediator"
custom_bot_ai.py(44, 5): Overridden symbol