### PR TITLE
style: format code with black and isort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!--next-version-placeholder-->
 
+## v3.11.1 (2026-07-30)
+
+### Fix
+
+* Replace `UnitTypeId.COMMANDCENTER` with `ai.base_townhall_type` in expansion checks ([`a408234`](https://github.com/AresSC2/ares-sc2/commit/a408234f6cfeb09c36b43b8afc1762b2e3e58842))
+
 ## v3.11.0 (2026-07-29)
 
 ### Feature

--- a/docs/tutorials/custom_behaviors.md
+++ b/docs/tutorials/custom_behaviors.md
@@ -55,7 +55,7 @@ As long as our behavior class follows the `CombatIndividualBehavior` Protocol, w
 our existing `offensive_attack` `CombatManeuver`. 
 - `CombatIndividualBehavior` Protocol says we should implement an `execute` method with the following signature:
 
-`def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:`
+`def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:`
 
 Notice this method should return a `booleon`, this should return `True` if this implemented
 `CombatIndividualBehavior` carried out an action, and `False` otherwise.
@@ -65,6 +65,8 @@ With this is mind let's implement a `SiegeTankDecision` custom behavior, you cou
 
 ```python
 # siege_tank_decision.py`
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -93,7 +95,7 @@ class SiegeTankDecision(CombatIndividualBehavior):
 
     unit: Unit
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         unit_pos: Point2 = self.unit.position
         type_id: UnitTypeId = self.unit.type_id
         

--- a/sc2_helper/combat_simulator.py
+++ b/sc2_helper/combat_simulator.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from .sc2_helper import CombatPredictor, CombatSettings
 
 
@@ -112,7 +110,7 @@ class CombatSimulator:
 
     def predict_engage(
         self, own_units, enemy_units, optimistic: bool = False, defender_player: int = 0
-    ) -> Tuple[bool, float]:
+    ) -> tuple[bool, float]:
         """
         Predict an engagement between two sets of units and returns a tuple containing Winner(True if own_units won)
         and winner's units' health left after engagement.

--- a/sc2_helper/combat_simulator.py
+++ b/sc2_helper/combat_simulator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .sc2_helper import CombatPredictor, CombatSettings
 
 

--- a/sc2_helper/helper_functions.py
+++ b/sc2_helper/helper_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .sc2_helper import circles_intersect as r_circles_intersect
 from .sc2_helper import find_points_inside_circle as r_find_points_inside_circle
 

--- a/sc2_helper/helper_functions.py
+++ b/sc2_helper/helper_functions.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from .sc2_helper import circles_intersect as r_circles_intersect
 from .sc2_helper import find_points_inside_circle as r_find_points_inside_circle
 
@@ -17,5 +15,5 @@ def circles_intersect(
 
 def find_points_inside_circle(
     point, radius: float, map_height: int, map_width: int
-) -> List[(int, int)]:
+) -> list[(int, int)]:
     return r_find_points_inside_circle(point, radius, map_height, map_width)

--- a/sc2_helper/test.py
+++ b/sc2_helper/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from time import perf_counter_ns
 
 from sc2 import BotAI, Difficulty, Race, UnitTypeId, maps, run_game

--- a/src/ares/__init__.py
+++ b/src/ares/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "3.11.0"
+__version__ = "3.11.1"
 
 from .main import *  # noqa: F403 F401

--- a/src/ares/behavior_exectioner.py
+++ b/src/ares/behavior_exectioner.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ares.behaviors.behavior import Behavior

--- a/src/ares/behavior_exectioner.py
+++ b/src/ares/behavior_exectioner.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ares.behaviors.behavior import Behavior
@@ -25,9 +26,9 @@ class BehaviorExecutioner:
 
     """
 
-    def __init__(self, ai: "AresBot", config: dict, mediator: ManagerMediator):
+    def __init__(self, ai: AresBot, config: dict, mediator: ManagerMediator):
         """Inits BehaviorExecutioner class."""
-        self.ai: "AresBot" = ai
+        self.ai: AresBot = ai
         self.config: dict = config
         self.mediator: ManagerMediator = mediator
         self.behaviors: list = []

--- a/src/ares/behaviors/behavior.py
+++ b/src/ares/behaviors/behavior.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from ares.managers.manager_mediator import ManagerMediator
@@ -9,17 +10,22 @@ if TYPE_CHECKING:
 class Behavior(Protocol):
     """Interface that all behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
-        Parameters:
-            ai: Bot object that will be running the game.
-            config: Dictionary with the data from the configuration file.
-            mediator: ManagerMediator used for getting information from other managers.
+        Parameters
+        ----------
+        ai : Bot
+            Bot object that will be running the game.
+        config : dict
+            Dictionary with the data from the configuration file.
+        mediator : ManagerMediator
+            ManagerMediator used for getting information from other managers.
 
-        Returns:
-            bool: Return value depends on combat/macros behavior interfaces.
+        Returns
+        -------
+        bool
+            Return value depends on combat/macros behavior interfaces.
             See those interfaces for more info.
-
         """
         ...

--- a/src/ares/behaviors/behavior.py
+++ b/src/ares/behaviors/behavior.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.managers.manager_mediator import ManagerMediator

--- a/src/ares/behaviors/behavior.py
+++ b/src/ares/behaviors/behavior.py
@@ -14,19 +14,13 @@ class Behavior(Protocol):
     def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
-        Parameters
-        ----------
-        ai : Bot
-            Bot object that will be running the game.
-        config : dict
-            Dictionary with the data from the configuration file.
-        mediator : ManagerMediator
-            ManagerMediator used for getting information from other managers.
+        Parameters:
+            ai: Bot object that will be running the game.
+            config: Dictionary with the data from the configuration file.
+            mediator: ManagerMediator used for getting information from other managers.
 
-        Returns
-        -------
-        bool
-            Return value depends on combat/macros behavior interfaces.
+        Returns:
+            bool: Return value depends on combat/macros behavior interfaces.
             See those interfaces for more info.
         """
         ...

--- a/src/ares/behaviors/combat/combat_behavior.py
+++ b/src/ares/behaviors/combat/combat_behavior.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,19 +11,24 @@ if TYPE_CHECKING:
 class CombatBehavior(Behavior, Protocol):
     """Interface that all combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Args:
-            ai: Bot object that will be running the game.
-            config: Dictionary with the data from the configuration file.
-            mediator: ManagerMediator used for getting information from other managers.
+        Parameters
+        ----------
+        ai : Bot
+            Bot object that will be running the game.
+        config : dict
+            Dictionary with the data from the configuration file.
+        mediator : ManagerMediator
+            ManagerMediator used for getting information from other managers.
 
-        Returns:
-            bool: MacroBehavior carried out an action.
-
+        Returns
+        -------
+        bool
+            MacroBehavior carried out an action.
         """
         ...

--- a/src/ares/behaviors/combat/combat_behavior.py
+++ b/src/ares/behaviors/combat/combat_behavior.py
@@ -18,18 +18,13 @@ class CombatBehavior(Behavior, Protocol):
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Parameters
-        ----------
-        ai : Bot
-            Bot object that will be running the game.
-        config : dict
-            Dictionary with the data from the configuration file.
-        mediator : ManagerMediator
-            ManagerMediator used for getting information from other managers.
+        Args:
+            ai: Bot object that will be running the game.
+            config: Dictionary with the data from the configuration file.
+            mediator: ManagerMediator used for getting information from other managers.
 
-        Returns
-        -------
-        bool
-            MacroBehavior carried out an action.
+        Returns:
+            bool: MacroBehavior carried out an action.
+
         """
         ...

--- a/src/ares/behaviors/combat/combat_behavior.py
+++ b/src/ares/behaviors/combat/combat_behavior.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior

--- a/src/ares/behaviors/combat/combat_maneuver.py
+++ b/src/ares/behaviors/combat/combat_maneuver.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from ares.behaviors.behavior import Behavior
 from ares.managers.manager_mediator import ManagerMediator
@@ -85,9 +87,7 @@ class CombatManeuver(Behavior):
 
     def add(
         self,
-        behavior: Union[
-            "CombatIndividualBehavior", "CombatGroupBehavior", "CombatManeuver"
-        ],
+        behavior: CombatIndividualBehavior | CombatGroupBehavior | CombatManeuver,
     ) -> None:
         """
         Args:

--- a/src/ares/behaviors/combat/combat_maneuver.py
+++ b/src/ares/behaviors/combat/combat_maneuver.py
@@ -96,7 +96,7 @@ class CombatManeuver(Behavior):
         """
         self.micros.append(behavior)
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for order in self.micros:
             if order.execute(ai, config, mediator):
                 # executed an action

--- a/src/ares/behaviors/combat/group/a_move_group.py
+++ b/src/ares/behaviors/combat/group/a_move_group.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -34,7 +36,7 @@ class AMoveGroup(CombatGroupBehavior):
     group_tags: set[int]
     target: Point2 | Unit
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/group/a_move_group.py
+++ b/src/ares/behaviors/combat/group/a_move_group.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_sorted_by_distance_to
 from sc2.ids.ability_id import AbilityId
@@ -32,7 +32,7 @@ class AMoveGroup(CombatGroupBehavior):
 
     group: list[Unit]
     group_tags: set[int]
-    target: Union[Point2, Unit]
+    target: Point2 | Unit
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:

--- a/src/ares/behaviors/combat/group/combat_group_behavior.py
+++ b/src/ares/behaviors/combat/group/combat_group_behavior.py
@@ -20,19 +20,13 @@ class CombatGroupBehavior(Behavior, Protocol):
     def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
-        Parameters
-        ----------
-        ai : AresBot
-            AresBot instance.
-        config : dict
-            Dictionary with the data from the configuration file.
-        mediator : ManagerMediator
-            Mediator instance.
+        Parameters:
+            ai (AresBot): AresBot instance
+            config (dict): Dictionary with the data from the configuration file.
+            mediator (ManagerMediator): Mediator instance
 
-        Returns
-        -------
-        bool
-            CombatGroupBehavior carried out an action.
+        Returns:
+            bool: CombatGroupBehavior carried out an action.
         """
         ...
 

--- a/src/ares/behaviors/combat/group/combat_group_behavior.py
+++ b/src/ares/behaviors/combat/group/combat_group_behavior.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from cython_extensions import cy_distance_to_squared

--- a/src/ares/behaviors/combat/group/combat_group_behavior.py
+++ b/src/ares/behaviors/combat/group/combat_group_behavior.py
@@ -31,7 +31,7 @@ class CombatGroupBehavior(Behavior, Protocol):
     def duplicate_or_similar_order(
         self,
         unit: Unit,
-        target: Union[Point2, Unit],
+        target: Point2 | Unit,
         order_type: AbilityId,
         distance_check_squared: float = 2.0,
     ) -> bool:

--- a/src/ares/behaviors/combat/group/combat_group_behavior.py
+++ b/src/ares/behaviors/combat/group/combat_group_behavior.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Protocol, Union
+from __future__ import annotations
+from typing import TYPE_CHECKING, Protocol
 
 from cython_extensions import cy_distance_to_squared
 from sc2.ids.ability_id import AbilityId
@@ -15,16 +16,22 @@ if TYPE_CHECKING:
 class CombatGroupBehavior(Behavior, Protocol):
     """Interface that all group combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
-        Parameters:
-            ai (AresBot): AresBot instance
-            config (dict): Dictionary with the data from the configuration file.
-            mediator (ManagerMediator): Mediator instance
+        Parameters
+        ----------
+        ai : AresBot
+            AresBot instance.
+        config : dict
+            Dictionary with the data from the configuration file.
+        mediator : ManagerMediator
+            Mediator instance.
 
-        Returns:
-            bool: CombatGroupBehavior carried out an action.
+        Returns
+        -------
+        bool
+            CombatGroupBehavior carried out an action.
         """
         ...
 

--- a/src/ares/behaviors/combat/group/group_use_ability.py
+++ b/src/ares/behaviors/combat/group/group_use_ability.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/group/group_use_ability.py
+++ b/src/ares/behaviors/combat/group/group_use_ability.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -45,7 +46,7 @@ class GroupUseAbility(CombatGroupBehavior):
     target: Point2 | Unit | None
     sync_command: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
         issue_command: bool

--- a/src/ares/behaviors/combat/group/group_use_ability.py
+++ b/src/ares/behaviors/combat/group/group_use_ability.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from sc2.ids.ability_id import AbilityId
 from sc2.position import Point2
@@ -42,7 +42,7 @@ class GroupUseAbility(CombatGroupBehavior):
     ability: AbilityId
     group: list[Unit]
     group_tags: set[int]
-    target: Union[Point2, Unit, None]
+    target: Point2 | Unit | None
     sync_command: bool = True
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:

--- a/src/ares/behaviors/combat/group/keep_group_safe.py
+++ b/src/ares/behaviors/combat/group/keep_group_safe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/group/keep_group_safe.py
+++ b/src/ares/behaviors/combat/group/keep_group_safe.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sc2.unit import Unit
@@ -34,7 +34,7 @@ class KeepGroupSafe(CombatGroupBehavior):
     """
 
     group: list[Unit]
-    close_enemy: Union[Units, list[Unit]]
+    close_enemy: list[Unit] | Units
     grid: np.ndarray
     attack_in_range_enemy: bool = True
 

--- a/src/ares/behaviors/combat/group/keep_group_safe.py
+++ b/src/ares/behaviors/combat/group/keep_group_safe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,7 @@ class KeepGroupSafe(CombatGroupBehavior):
     grid: np.ndarray
     attack_in_range_enemy: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/group/path_group_to_target.py
+++ b/src/ares/behaviors/combat/group/path_group_to_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/group/path_group_to_target.py
+++ b/src/ares/behaviors/combat/group/path_group_to_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -71,7 +72,7 @@ class PathGroupToTarget(CombatGroupBehavior):
     danger_threshold: float = 5.0
     prevent_duplicate: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert isinstance(
             self.start, Point2
         ), f"{self.start} should be `Point2`, got {type(self.start)}"

--- a/src/ares/behaviors/combat/group/stutter_group_back.py
+++ b/src/ares/behaviors/combat/group/stutter_group_back.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/group/stutter_group_back.py
+++ b/src/ares/behaviors/combat/group/stutter_group_back.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from cython_extensions import cy_distance_to_squared, cy_sorted_by_distance_to
@@ -43,7 +43,7 @@ class StutterGroupBack(CombatGroupBehavior):
     group: list[Unit]
     group_tags: set[int]
     group_position: Point2
-    target: Union[Point2, Unit]
+    target: Point2 | Unit
     grid: np.ndarray
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:

--- a/src/ares/behaviors/combat/group/stutter_group_back.py
+++ b/src/ares/behaviors/combat/group/stutter_group_back.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -46,7 +47,7 @@ class StutterGroupBack(CombatGroupBehavior):
     target: Point2 | Unit
     grid: np.ndarray
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 
@@ -96,7 +97,7 @@ class StutterGroupBack(CombatGroupBehavior):
 
         return True
 
-    def _calculate_retreat_position(self, ai: "AresBot") -> Point2:
+    def _calculate_retreat_position(self, ai: AresBot) -> Point2:
         """Search 8 directions for somewhere to retreat to."""
         distance = len(self.group) * 1.5
 

--- a/src/ares/behaviors/combat/group/stutter_group_forward.py
+++ b/src/ares/behaviors/combat/group/stutter_group_forward.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/group/stutter_group_forward.py
+++ b/src/ares/behaviors/combat/group/stutter_group_forward.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_center, cy_in_attack_range, cy_sorted_by_distance_to
 from sc2.ids.ability_id import AbilityId
@@ -30,8 +30,8 @@ class StutterGroupForward(CombatGroupBehavior):
     group: list[Unit]
     group_tags: set[int]
     group_position: Point2
-    target: Union[Point2, Unit]
-    enemies: Union[Units, list[Unit]]
+    target: Point2 | Unit
+    enemies: list[Unit] | Units
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:

--- a/src/ares/behaviors/combat/group/stutter_group_forward.py
+++ b/src/ares/behaviors/combat/group/stutter_group_forward.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,7 +34,7 @@ class StutterGroupForward(CombatGroupBehavior):
     target: Point2 | Unit
     enemies: list[Unit] | Units
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/individual/a_move.py
+++ b/src/ares/behaviors/combat/individual/a_move.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/a_move.py
+++ b/src/ares/behaviors/combat/individual/a_move.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to
 from sc2.position import Point2
@@ -34,7 +34,7 @@ class AMove(CombatIndividualBehavior):
     """
 
     unit: Unit
-    target: Union[Point2, Unit]
+    target: Point2 | Unit
     success_at_distance: float = 7.0
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:

--- a/src/ares/behaviors/combat/individual/a_move.py
+++ b/src/ares/behaviors/combat/individual/a_move.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -37,7 +38,7 @@ class AMove(CombatIndividualBehavior):
     target: Point2 | Unit
     success_at_distance: float = 7.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             self.success_at_distance > 0
             and cy_distance_to(self.unit.position, self.target.position)

--- a/src/ares/behaviors/combat/individual/attack_target.py
+++ b/src/ares/behaviors/combat/individual/attack_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/attack_target.py
+++ b/src/ares/behaviors/combat/individual/attack_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,7 +37,7 @@ class AttackTarget(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         self.unit.attack(self.target)
         return True

--- a/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -20,23 +21,27 @@ if TYPE_CHECKING:
 @dataclass
 class AutoUseAOEAbility(CombatIndividualBehavior):
     """Pass in a unit and it will find an AOE to use
-        and cast it.
+    and cast it.
 
-    Attributes:
-        unit: The unit that potentially has an AOE ability.
-        targets: The targets we want to hit.
-        min_targets: Minimum targets to hit with spell.
-        bonus_tags: Give more emphasize on this unit tags.
-            For example, perhaps a ravager can do corrosive bile
-            Provide enemy tags that are currently fungaled?
-            Default is empty `Set`
-        recalculate: If unit is already using ability, should
-            we recalculate this behavior?
-            WARNING: could have performance impact
-            Default is False.
-        stack_same_spell: Stack spell in same position?
-            Default is False.
-
+    Attributes
+    ----------
+    unit : Unit
+        The unit that potentially has an AOE ability.
+    targets : Units
+        The targets we want to hit.
+    min_targets : int
+        Minimum targets to hit with spell.
+    bonus_tags : set[int] = None
+        Give more emphasize on this unit tags.
+        For example, perhaps a ravager can do corrosive bile
+        Provide enemy tags that are currently fungaled?
+        Default is empty `set`.
+    recalculate : bool = False
+        If unit is already using ability, should
+        we recalculate this behavior?
+        WARNING: could have performance impact.
+    stack_same_spell : bool = False
+        Stack spell in same position?
     """
 
     unit: Unit
@@ -45,7 +50,7 @@ class AutoUseAOEAbility(CombatIndividualBehavior):
     recalculate: bool = False
     stack_same_spell: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         _abilities: set[AbilityId] = self.unit.abilities
         for ability in AOE_ABILITY_SPELLS_INFO:
             if ability not in _abilities:

--- a/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
@@ -22,27 +22,23 @@ if TYPE_CHECKING:
 @dataclass
 class AutoUseAOEAbility(CombatIndividualBehavior):
     """Pass in a unit and it will find an AOE to use
-    and cast it.
+        and cast it.
 
-    Attributes
-    ----------
-    unit : Unit
-        The unit that potentially has an AOE ability.
-    targets : Units
-        The targets we want to hit.
-    min_targets : int
-        Minimum targets to hit with spell.
-    bonus_tags : set[int] = None
-        Give more emphasize on this unit tags.
-        For example, perhaps a ravager can do corrosive bile
-        Provide enemy tags that are currently fungaled?
-        Default is empty `set`.
-    recalculate : bool = False
-        If unit is already using ability, should
-        we recalculate this behavior?
-        WARNING: could have performance impact.
-    stack_same_spell : bool = False
-        Stack spell in same position?
+    Attributes:
+        unit: The unit that potentially has an AOE ability.
+        targets: The targets we want to hit.
+        min_targets: Minimum targets to hit with spell.
+        bonus_tags: Give more emphasize on this unit tags.
+            For example, perhaps a ravager can do corrosive bile
+            Provide enemy tags that are currently fungaled?
+            Default is empty `Set`
+        recalculate: If unit is already using ability, should
+            we recalculate this behavior?
+            WARNING: could have performance impact
+            Default is False.
+        stack_same_spell: Stack spell in same position?
+            Default is False.
+
     """
 
     unit: Unit

--- a/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_closer_than
 from sc2.data import Race
@@ -41,7 +41,7 @@ class AutoUseAOEAbility(CombatIndividualBehavior):
 
     unit: Unit
     targets: list[Unit]
-    bonus_tags: Optional[set] = field(default_factory=set)
+    bonus_tags: set | None = field(default_factory=set)
     recalculate: bool = False
     stack_same_spell: bool = False
 

--- a/src/ares/behaviors/combat/individual/combat_individual_behavior.py
+++ b/src/ares/behaviors/combat/individual/combat_individual_behavior.py
@@ -18,19 +18,14 @@ class CombatIndividualBehavior(Behavior, Protocol):
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Parameters
-        ----------
-        ai : AresBot
-            Bot object that will be running the game.
-        config : dict
-            Dictionary with the data from the configuration file.
-        mediator : ManagerMediator
-            ManagerMediator used for getting information from other managers.
+        Args:
+            ai: Bot object that will be running the game.
+            config: Dictionary with the data from the configuration file.
+            mediator: ManagerMediator used for getting information from other managers.
 
-        Returns
-        -------
-        bool
-            True if this CombatIndividualBehavior carried out an action,
-            False otherwise.
+        Returns:
+            bool: True if this CombatIndividualBehavior carried out an action,
+                False otherwise.
+
         """
         ...

--- a/src/ares/behaviors/combat/individual/combat_individual_behavior.py
+++ b/src/ares/behaviors/combat/individual/combat_individual_behavior.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,20 +11,25 @@ if TYPE_CHECKING:
 class CombatIndividualBehavior(Behavior, Protocol):
     """Interface that all combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Args:
-            ai: Bot object that will be running the game.
-            config: Dictionary with the data from the configuration file.
-            mediator: ManagerMediator used for getting information from other managers.
+        Parameters
+        ----------
+        ai : AresBot
+            Bot object that will be running the game.
+        config : dict
+            Dictionary with the data from the configuration file.
+        mediator : ManagerMediator
+            ManagerMediator used for getting information from other managers.
 
-        Returns:
-            bool: True if this CombatIndividualBehavior carried out an action,
-                False otherwise.
-
+        Returns
+        -------
+        bool
+            True if this CombatIndividualBehavior carried out an action,
+            False otherwise.
         """
         ...

--- a/src/ares/behaviors/combat/individual/combat_individual_behavior.py
+++ b/src/ares/behaviors/combat/individual/combat_individual_behavior.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior

--- a/src/ares/behaviors/combat/individual/drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/drop_cargo.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/drop_cargo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,7 @@ class DropCargo(CombatIndividualBehavior):
     unit: Unit
     target: Point2
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # TODO: Expand logic as needed, initial working version.
         # no action executed
         if self.unit.cargo_used == 0 or not cy_in_pathing_grid_ma(

--- a/src/ares/behaviors/combat/individual/ghost_snipe.py
+++ b/src/ares/behaviors/combat/individual/ghost_snipe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/ghost_snipe.py
+++ b/src/ares/behaviors/combat/individual/ghost_snipe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -30,7 +31,7 @@ class GhostSnipe(CombatIndividualBehavior):
     unit: Unit
     close_enemy: list[Unit] | Units
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             ai.enemy_race != Race.Zerg
             or not self.close_enemy
@@ -48,7 +49,7 @@ class GhostSnipe(CombatIndividualBehavior):
         return False
 
     def get_snipe_target(
-    ) -> Optional[Unit]:
+        self, ai: AresBot, ghosts: list[Unit], units: Units
     ) -> Unit | None:
         max_value: float = 0.0
         target: Unit | None = None

--- a/src/ares/behaviors/combat/individual/ghost_snipe.py
+++ b/src/ares/behaviors/combat/individual/ghost_snipe.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared
 from sc2.data import Race
@@ -28,7 +28,7 @@ class GhostSnipe(CombatIndividualBehavior):
     """
 
     unit: Unit
-    close_enemy: Union[list[Unit], Units]
+    close_enemy: list[Unit] | Units
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         if (
@@ -48,10 +48,10 @@ class GhostSnipe(CombatIndividualBehavior):
         return False
 
     def get_snipe_target(
-        self, ai: "AresBot", ghosts: list[Unit], units: Units
     ) -> Optional[Unit]:
+    ) -> Unit | None:
         max_value: float = 0.0
-        target: Optional[Unit] = None
+        target: Unit | None = None
 
         for unit in units:
             if (

--- a/src/ares/behaviors/combat/individual/keep_unit_safe.py
+++ b/src/ares/behaviors/combat/individual/keep_unit_safe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/keep_unit_safe.py
+++ b/src/ares/behaviors/combat/individual/keep_unit_safe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,7 @@ class KeepUnitSafe(CombatIndividualBehavior):
     unit: Unit
     grid: np.ndarray
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no action executed
         if mediator.is_position_safe(grid=self.grid, position=self.unit.position):
             return False

--- a/src/ares/behaviors/combat/individual/medivac_heal.py
+++ b/src/ares/behaviors/combat/individual/medivac_heal.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/medivac_heal.py
+++ b/src/ares/behaviors/combat/individual/medivac_heal.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -31,7 +32,7 @@ class MedivacHeal(CombatIndividualBehavior):
     grid: np.ndarray
     keep_safe: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.unit.type_id != UnitTypeId.MEDIVAC:
             return False
 

--- a/src/ares/behaviors/combat/individual/move_to_safe_target.py
+++ b/src/ares/behaviors/combat/individual/move_to_safe_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/move_to_safe_target.py
+++ b/src/ares/behaviors/combat/individual/move_to_safe_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -66,7 +67,7 @@ class MoveToSafeTarget(CombatIndividualBehavior):
     danger_threshold: float = 5.0
     radius: float = 12.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if cy_distance_to(self.unit.position, self.target) <= self.success_at_distance:
             return False
 

--- a/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -51,7 +52,7 @@ class NydusPathUnitToTarget(CombatIndividualBehavior):
     smoothing: bool = False
     exit_nydus_max_influence: float = 10.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         distance_to_target: float = cy_distance_to(self.unit.position, self.target)
         # no action executed
         if distance_to_target < self.success_at_distance:

--- a/src/ares/behaviors/combat/individual/path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/path_unit_to_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/path_unit_to_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,7 +57,7 @@ class PathUnitToTarget(CombatIndividualBehavior):
     danger_distance: float = 20.0
     danger_threshold: float = 5.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         distance_to_target: float = cy_distance_to(self.unit.position, self.target)
         # no action executed
         if distance_to_target < self.success_at_distance:

--- a/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sc2.position import Point2
@@ -30,7 +30,7 @@ class PickUpAndDropCargo(CombatIndividualBehavior):
 
     unit: Unit # medivac for example
     grid: np.ndarray = self.mediator.get_ground_grid
-    pickup_targets: Union[Units, list[Unit]] = self.workers
+    pickup_targets: Units | list[Unit] = self.workers
     self.register_behavior(
         PickUpAndDropCargo(unit, grid, pickup_targets, self.ai.game_info.map_center)
     )
@@ -54,9 +54,9 @@ class PickUpAndDropCargo(CombatIndividualBehavior):
 
     unit: Unit
     grid: np.ndarray
-    pickup_targets: Union[Units, list[Unit]]
+    pickup_targets: list[Unit] | Units
     target: Point2
-    cargo_switch_to_role: Optional[UnitRole] = None
+    cargo_switch_to_role: UnitRole | None = None
     should_drop_units: bool = True
     keep_dropship_safe: bool = True
     success_at_distance: float = 2.0

--- a/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -61,7 +62,7 @@ class PickUpAndDropCargo(CombatIndividualBehavior):
     keep_dropship_safe: bool = True
     success_at_distance: float = 2.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # check for units to pick up.
         if PickUpCargo(
             unit=self.unit,

--- a/src/ares/behaviors/combat/individual/pick_up_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_cargo.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/pick_up_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_cargo.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -49,7 +50,7 @@ class PickUpCargo(CombatIndividualBehavior):
     pickup_targets: list[Unit] | Units
     cargo_switch_to_role: UnitRole | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no action executed
         if not self.pickup_targets or self.unit.type_id not in PICKUP_RANGE:
             # just ensure tags inside are assigned correctly

--- a/src/ares/behaviors/combat/individual/pick_up_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_cargo.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from cython_extensions import cy_closest_to, cy_distance_to
@@ -31,7 +31,7 @@ class PickUpCargo(CombatIndividualBehavior):
 
     unit: Unit # medivac for example
     grid: np.ndarray = self.mediator.get_ground_grid
-    pickup_targets: Union[Units, list[Unit]] = self.workers
+    pickup_targets: Units | list[Unit] = self.workers
     self.register_behavior(PickUpCargo(unit, grid, pickup_targets))
     ```
 
@@ -46,8 +46,8 @@ class PickUpCargo(CombatIndividualBehavior):
 
     unit: Unit
     grid: np.ndarray
-    pickup_targets: Union[Units, list[Unit]]
-    cargo_switch_to_role: Optional[UnitRole] = None
+    pickup_targets: list[Unit] | Units
+    cargo_switch_to_role: UnitRole | None = None
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         # no action executed

--- a/src/ares/behaviors/combat/individual/place_predictive_aoe.py
+++ b/src/ares/behaviors/combat/individual/place_predictive_aoe.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to
 from sc2.ids.ability_id import AbilityId
@@ -36,7 +36,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
     """
 
     unit: Unit
-    path: List[Point2]
+    path: list[Point2]
     enemy_center_unit: Unit
     aoe_ability: AbilityId
     ability_delay: int
@@ -85,8 +85,8 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
         current_position: Point2,
         current_target: Point2,
         distance_per_step: float,
-        next_target: Optional[Point2] = None,
-    ) -> Tuple[Point2, bool]:
+        next_target: Point2 | None = None,
+    ) -> tuple[Point2, bool]:
         """Calculate where a unit will be on the next step.
 
         Assumes knowledge of the unit's current position, target position, and that the
@@ -108,7 +108,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
 
         Returns
         -------
-        Tuple[Point2, bool] :
+        tuple[Point2, bool] :
             Point2 is where the unit will be
             bool is whether the unit reached `current_target` in this step
 
@@ -141,24 +141,24 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
         )
 
     def _get_unit_real_path(
-        self, unit_path: List[Point2], unit_speed: float
-    ) -> List[Point2]:
+        self, unit_path: list[Point2], unit_speed: float
+    ) -> list[Point2]:
         """Find the location of the unit at each game step given its path.
 
         Parameters
         ----------
-        unit_path: List[Point2]
+        unit_path: list[Point2]
             Where the unit is being told to move.
         unit_speed: float
             How far the unit moves each game step.
 
         Returns
         -------
-        List[Point2] :
+        list[Point2] :
             Where the unit will be at each game iteration.
 
         """
-        real_path: List[Point2] = [unit_path[0]]
+        real_path: list[Point2] = [unit_path[0]]
         curr_target_idx: int = 1
         # 100 should be overkill, but I'm really just trying to avoid a `while` loop
         for step in range(100):
@@ -186,13 +186,13 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
         return real_path
 
     def _get_chasing_unit_path(
-        self, target_unit_path: List[Point2], start_position: Point2, unit_speed: float
-    ) -> Tuple[List[Point2], bool]:
+        self, target_unit_path: list[Point2], start_position: Point2, unit_speed: float
+    ) -> tuple[list[Point2], bool]:
         """Calculate the path the chasing unit will take to catch the target unit.
 
         Arguments
         ---------
-        target_unit_path: List[Point2]
+        target_unit_path: list[Point2]
             Where the target unit is going to be at each game iteration.
         start_position: Point2
             Where the chasing unit is starting from.
@@ -201,14 +201,13 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
 
         Returns
         -------
-        Tuple[List[Point2], bool] :
-            List[Point2] is the chasing unit's path
+        tuple[list[Point2], bool] :
+            list[Point2] is the chasing unit's path
             bool is whether the chasing unit caught the target unit
-
         """
         reached_target: bool = False
 
-        unit_path: List[Point2] = [start_position]
+        unit_path: list[Point2] = [start_position]
         target_idx = 0
 
         for i in range(100):

--- a/src/ares/behaviors/combat/individual/place_predictive_aoe.py
+++ b/src/ares/behaviors/combat/individual/place_predictive_aoe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/src/ares/behaviors/combat/individual/place_predictive_aoe.py
+++ b/src/ares/behaviors/combat/individual/place_predictive_aoe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -43,7 +44,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
     reaper_grenade_range: float = 5.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.aoe_ability in self.unit.abilities:
             # try to fire the ability if we find a position
@@ -55,7 +56,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
         # no position found or the ability isn't ready
         return False
 
-    def _calculate_target_position(self, ai: "AresBot") -> Point2:
+    def _calculate_target_position(self, ai: AresBot) -> Point2:
         """Calculate where we want to put the AoE.
 
         Returns

--- a/src/ares/behaviors/combat/individual/queen_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/queen_spread_creep.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/queen_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/queen_spread_creep.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -41,7 +42,7 @@ class QueenSpreadCreep(CombatIndividualBehavior):
     cancel_if_close_enemy: bool = True
     pre_move_queen_to_tumor: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         spreading: bool = self.unit.is_using_ability(AbilityId.BUILD_CREEPTUMOR)
 
         grid: np.ndarray = mediator.get_ground_grid

--- a/src/ares/behaviors/combat/individual/raven_auto_turret.py
+++ b/src/ares/behaviors/combat/individual/raven_auto_turret.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/raven_auto_turret.py
+++ b/src/ares/behaviors/combat/individual/raven_auto_turret.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -27,7 +28,7 @@ class RavenAutoTurret(CombatIndividualBehavior):
     unit: Unit
     all_close_enemy: list[Unit]
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if AbilityId.BUILDAUTOTURRET_AUTOTURRET not in self.unit.abilities:
             return False
 

--- a/src/ares/behaviors/combat/individual/reaper_grenade.py
+++ b/src/ares/behaviors/combat/individual/reaper_grenade.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/reaper_grenade.py
+++ b/src/ares/behaviors/combat/individual/reaper_grenade.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,7 +57,7 @@ class ReaperGrenade(CombatIndividualBehavior):
     place_predictive: bool = True
     reaper_grenade_range: float = 5.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             not self.enemy_units
             or AbilityId.KD8CHARGE_KD8CHARGE not in self.unit.abilities

--- a/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
+++ b/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
+++ b/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -55,7 +56,7 @@ class ShootAndMoveToTarget(CombatIndividualBehavior):
     dist_to_target: float = 4.0
     attack_destructables: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if ShootTargetInRange(self.unit, self.enemy_units).execute(
             ai, config, mediator
         ):

--- a/src/ares/behaviors/combat/individual/shoot_target_in_range.py
+++ b/src/ares/behaviors/combat/individual/shoot_target_in_range.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/shoot_target_in_range.py
+++ b/src/ares/behaviors/combat/individual/shoot_target_in_range.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +44,7 @@ class ShootTargetInRange(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if not self.targets:
             return False

--- a/src/ares/behaviors/combat/individual/siege_tank_decision.py
+++ b/src/ares/behaviors/combat/individual/siege_tank_decision.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/siege_tank_decision.py
+++ b/src/ares/behaviors/combat/individual/siege_tank_decision.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -52,7 +53,7 @@ class SiegeTankDecision(CombatIndividualBehavior):
     remain_sieged: bool = False
     force_unsiege: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         type_id: UnitTypeId = self.unit.type_id
         if type_id not in TANK_TYPES:
             return False

--- a/src/ares/behaviors/combat/individual/stutter_unit_back.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_back.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/stutter_unit_back.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_back.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +44,7 @@ class StutterUnitBack(CombatIndividualBehavior):
     grid: np.ndarray | None = None
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/combat/individual/stutter_unit_back.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_back.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from cython_extensions import cy_attack_ready
@@ -40,7 +40,7 @@ class StutterUnitBack(CombatIndividualBehavior):
     unit: Unit
     target: Unit
     kite_via_pathing: bool = True
-    grid: Optional[np.ndarray] = None
+    grid: np.ndarray | None = None
 
     def execute(
         self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs

--- a/src/ares/behaviors/combat/individual/stutter_unit_forward.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_forward.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/stutter_unit_forward.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_forward.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,7 +37,7 @@ class StutterUnitForward(CombatIndividualBehavior):
     target: Unit
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/combat/individual/tumor_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/tumor_spread_creep.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/tumor_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/tumor_spread_creep.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +44,7 @@ class TumorSpreadCreep(CombatIndividualBehavior):
     unit: Unit
     target: Point2
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if AbilityId.BUILD_CREEPTUMOR_TUMOR not in self.unit.abilities:
             return False
 

--- a/src/ares/behaviors/combat/individual/use_ability.py
+++ b/src/ares/behaviors/combat/individual/use_ability.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/use_ability.py
+++ b/src/ares/behaviors/combat/individual/use_ability.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -44,7 +45,7 @@ class UseAbility(CombatIndividualBehavior):
     target: Point2 | Unit | None = None
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.ability not in self.unit.abilities:
             return False

--- a/src/ares/behaviors/combat/individual/use_ability.py
+++ b/src/ares/behaviors/combat/individual/use_ability.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from sc2.ids.ability_id import AbilityId
 from sc2.position import Point2
@@ -24,7 +24,7 @@ class UseAbility(CombatIndividualBehavior):
     from sc2.ids.ability_id import AbilityId
 
     unit: Unit
-    target: Union[Unit, Point2]
+    target: Point2 | Unit
     self.register_behavior(
         UseAbility(
             AbilityId.FUNGALGROWTH_FUNGALGROWTH, unit, target
@@ -41,7 +41,7 @@ class UseAbility(CombatIndividualBehavior):
 
     ability: AbilityId
     unit: Unit
-    target: Optional[Union[Point2, Unit]] = None
+    target: Point2 | Unit | None = None
 
     def execute(
         self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs

--- a/src/ares/behaviors/combat/individual/use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/use_aoe_ability.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/use_aoe_ability.py
@@ -33,31 +33,26 @@ if TYPE_CHECKING:
 class UseAOEAbility(CombatIndividualBehavior):
     """Attempt to use AOE ability for a unit.
 
-    Attributes
-    ----------
-    unit : Unit
-        The unit that potentially has an AOE ability.
-    ability_id : AbilityId
-        Ability we want to use.
-    targets : Units
-        The targets we want to hit.
-    min_targets : int
-        Minimum targets to hit with spell.
-    avoid_own_flying : bool = False
-        Avoid own flying with this spell?
-    avoid_own_ground : bool = False
-        Avoid own ground with this spell?
-    bonus_tags : set[int] = None
-        Give more emphasize on this unit tags.
-        For example, perhaps a ravager can do corrosive bile
-        Provide enemy tags that are currently fungaled?
-        Default is empty `set`.
-    recalculate : bool = False
-        If unit is already using ability, should
-        we recalculate this behavior?
-        WARNING: could have performance impact.
-    stack_same_spell : bool = False
-        Stack spell in same position?
+    Attributes:
+        unit: The unit that potentially has an AOE ability.
+        ability_id: Ability we want to use.
+        targets: The targets we want to hit.
+        min_targets: Minimum targets to hit with spell.
+        avoid_own_flying: Avoid own flying with this spell?
+            Default is False.
+        avoid_own_ground: Avoid own ground with this spell?
+            Default is False.
+        bonus_tags: Give more emphasize on this unit tags.
+            For example, perhaps a ravager can do corrosive bile
+            Provide enemy tags that are currently fungaled?
+            Default is empty `Set`
+        recalculate: If unit is already using ability, should
+            we recalculate this behavior?
+            WARNING: could have performance impact
+            Default is False.
+        stack_same_spell: Stack spell in same position?
+            Default is False.
+
     """
 
     unit: Unit

--- a/src/ares/behaviors/combat/individual/use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/use_aoe_ability.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from cython_extensions import (
@@ -59,7 +59,7 @@ class UseAOEAbility(CombatIndividualBehavior):
     min_targets: int
     avoid_own_flying: bool = False
     avoid_own_ground: bool = False
-    bonus_tags: Optional[set] = field(default_factory=set)
+    bonus_tags: set | None = field(default_factory=set)
     recalculate: bool = False
     stack_same_spell: bool = False
 

--- a/src/ares/behaviors/combat/individual/use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/use_aoe_ability.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -31,26 +32,31 @@ if TYPE_CHECKING:
 class UseAOEAbility(CombatIndividualBehavior):
     """Attempt to use AOE ability for a unit.
 
-    Attributes:
-        unit: The unit that potentially has an AOE ability.
-        ability_id: Ability we want to use.
-        targets: The targets we want to hit.
-        min_targets: Minimum targets to hit with spell.
-        avoid_own_flying: Avoid own flying with this spell?
-            Default is False.
-        avoid_own_ground: Avoid own ground with this spell?
-            Default is False.
-        bonus_tags: Give more emphasize on this unit tags.
-            For example, perhaps a ravager can do corrosive bile
-            Provide enemy tags that are currently fungaled?
-            Default is empty `Set`
-        recalculate: If unit is already using ability, should
-            we recalculate this behavior?
-            WARNING: could have performance impact
-            Default is False.
-        stack_same_spell: Stack spell in same position?
-            Default is False.
-
+    Attributes
+    ----------
+    unit : Unit
+        The unit that potentially has an AOE ability.
+    ability_id : AbilityId
+        Ability we want to use.
+    targets : Units
+        The targets we want to hit.
+    min_targets : int
+        Minimum targets to hit with spell.
+    avoid_own_flying : bool = False
+        Avoid own flying with this spell?
+    avoid_own_ground : bool = False
+        Avoid own ground with this spell?
+    bonus_tags : set[int] = None
+        Give more emphasize on this unit tags.
+        For example, perhaps a ravager can do corrosive bile
+        Provide enemy tags that are currently fungaled?
+        Default is empty `set`.
+    recalculate : bool = False
+        If unit is already using ability, should
+        we recalculate this behavior?
+        WARNING: could have performance impact.
+    stack_same_spell : bool = False
+        Stack spell in same position?
     """
 
     unit: Unit
@@ -63,7 +69,7 @@ class UseAOEAbility(CombatIndividualBehavior):
     recalculate: bool = False
     stack_same_spell: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.ability_id not in AOE_ABILITY_SPELLS_INFO:
             logger.warning(
                 f"You're trying to use {self.ability_id} with `UseAOEAbility`, "
@@ -112,7 +118,7 @@ class UseAOEAbility(CombatIndividualBehavior):
         return False
 
     def _can_cast(
-        self, ai: "AresBot", mediator: ManagerMediator, position: Point2, radius: float
+        self, ai: AresBot, mediator: ManagerMediator, position: Point2, radius: float
     ) -> bool:
         can_cast: bool = (
             len(cy_closer_than(self.targets, radius, position)) >= self.min_targets

--- a/src/ares/behaviors/combat/individual/use_transfuse.py
+++ b/src/ares/behaviors/combat/individual/use_transfuse.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/use_transfuse.py
+++ b/src/ares/behaviors/combat/individual/use_transfuse.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to
 from sc2.ids.ability_id import AbilityId
@@ -29,7 +29,7 @@ class UseTransfuse(CombatIndividualBehavior):
     """
 
     unit: Unit
-    targets: Union[list[Unit], Units]
+    targets: list[Unit] | Units
     extra_range: float = 0.0
 
     def execute(

--- a/src/ares/behaviors/combat/individual/use_transfuse.py
+++ b/src/ares/behaviors/combat/individual/use_transfuse.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,7 +34,7 @@ class UseTransfuse(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.unit.is_using_ability(AbilityId.TRANSFUSION_TRANSFUSION):
             return True

--- a/src/ares/behaviors/combat/individual/worker_kite_back.py
+++ b/src/ares/behaviors/combat/individual/worker_kite_back.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/combat/individual/worker_kite_back.py
+++ b/src/ares/behaviors/combat/individual/worker_kite_back.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -55,7 +56,7 @@ class WorkerKiteBack(CombatIndividualBehavior):
     should_attack: bool = True
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/macro/addon_swap.py
+++ b/src/ares/behaviors/macro/addon_swap.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/addon_swap.py
+++ b/src/ares/behaviors/macro/addon_swap.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -50,7 +51,7 @@ class AddonSwap(MacroBehavior):
     addon_required: UnitTypeId
     precise_addon_structure_id: UnitTypeId | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert ai.race == Race.Terran, "Can only swap addons with Terran."
         # check if user provided a precise addon into addon_required
         if self.addon_required not in ADDON_TYPES:

--- a/src/ares/behaviors/macro/auto_supply.py
+++ b/src/ares/behaviors/macro/auto_supply.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING

--- a/src/ares/behaviors/macro/auto_supply.py
+++ b/src/ares/behaviors/macro/auto_supply.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -41,7 +42,7 @@ class AutoSupply(MacroBehavior):
     return_true_if_supply_required: bool = True
     closest_to: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self._num_supply_required(ai, mediator) > 0:
             supply_type: UnitTypeId = RACE_SUPPLY[ai.race]
             if ai.race == Race.Zerg:
@@ -58,7 +59,7 @@ class AutoSupply(MacroBehavior):
         return False
 
     @staticmethod
-    def _num_supply_required(ai: "AresBot", mediator: ManagerMediator) -> int:
+    def _num_supply_required(ai: AresBot, mediator: ManagerMediator) -> int:
         """
         TODO: Improve on this initial version
             Should calculate based on townhalls for Zerg only?

--- a/src/ares/behaviors/macro/build_structure.py
+++ b/src/ares/behaviors/macro/build_structure.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -172,7 +173,7 @@ class BuildStructure(MacroBehavior):
     def _enough_existing_at_this_base(self, mediator: ManagerMediator) -> bool:
         placement_dict: dict = mediator.get_placements_dict
         size: BuildingSize = STRUCTURE_TO_BUILDING_SIZE[self.structure_id]
-        potential_placements: dict[Point2:dict] = placement_dict[self.base_location][
+        potential_placements: dict[Point2, dict] = placement_dict[self.base_location][
             size
         ]
         taken: list[Point2] = [

--- a/src/ares/behaviors/macro/build_structure.py
+++ b/src/ares/behaviors/macro/build_structure.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -95,7 +96,7 @@ class BuildStructure(MacroBehavior):
     reaper_wall: bool = False
     find_alternative: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.structure_id not in STRUCTURE_TO_BUILDING_SIZE:
             logger.error(
                 f"Invalid structure type passed to `BuildStructure`: "
@@ -161,7 +162,7 @@ class BuildStructure(MacroBehavior):
                 return True
         return False
 
-    def _enough_existing(self, ai: "AresBot", mediator: ManagerMediator) -> bool:
+    def _enough_existing(self, ai: AresBot, mediator: ManagerMediator) -> bool:
         existing_structures = mediator.get_own_structures_dict[self.structure_id]
         num_existing: int = len(
             [s for s in existing_structures if s.is_ready]

--- a/src/ares/behaviors/macro/build_workers.py
+++ b/src/ares/behaviors/macro/build_workers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/build_workers.py
+++ b/src/ares/behaviors/macro/build_workers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -32,7 +33,7 @@ class BuildWorkers(MacroBehavior):
 
     to_count: int
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         worker_type: UnitTypeId = ai.worker_type
         if (
             ai.can_afford(worker_type)

--- a/src/ares/behaviors/macro/expansion_controller.py
+++ b/src/ares/behaviors/macro/expansion_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/expansion_controller.py
+++ b/src/ares/behaviors/macro/expansion_controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,8 @@ from ares.managers.manager_mediator import ManagerMediator
 class ExpansionController(MacroBehavior):
     """Manage expanding.
 
+    Examples
+    --------
     Example:
     ```py
     from ares.behaviors.macro import ExpansionController
@@ -25,16 +28,21 @@ class ExpansionController(MacroBehavior):
     )
     ```
 
-    Attributes:
-        to_count: The target base count.
-        can_afford_check: Check if we can afford expansion. Setting this to False
-            will allow the worker to move to a location ready to build the expansion.
-            Defaults to True.
-        check_location_is_safe: Check if we don't knowingly expand at a dangerous
-            location. Defaults to True.
-        max_pending: Maximum pending townhalls at any time. Defaults to 1.
-        prioritize: Will return True for this behavior if we can't afford expansion.
-            Default is False
+    Attributes
+    ----------
+    to_count : int
+        The target base count.
+    can_afford_check : bool = True
+        Check if we can afford expansion. Setting this to False
+        will allow the worker to move to a location ready to build
+        the expansion.
+    check_location_is_safe : bool = True
+        Check if we don't knowingly expand at a dangerous
+        location.
+    max_pending : int = 1
+        Maximum pending townhalls at any time.
+    prioritize : bool = False
+        Will return True for this behavior if we can't afford expansion.
     """
 
     to_count: int
@@ -43,7 +51,7 @@ class ExpansionController(MacroBehavior):
     max_pending: int = 1
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # already have enough / or enough pending
         if (
             len([th for th in ai.townhalls if th.is_ready])
@@ -68,7 +76,7 @@ class ExpansionController(MacroBehavior):
         return False
 
     def _get_next_expansion_location(
-        self, ai: "AresBot", mediator: ManagerMediator
+        self, ai: AresBot, mediator: ManagerMediator
     ) -> Point2 | None:
         grid: np.ndarray = mediator.get_ground_grid
         for el in mediator.get_own_expansions:

--- a/src/ares/behaviors/macro/expansion_controller.py
+++ b/src/ares/behaviors/macro/expansion_controller.py
@@ -29,21 +29,16 @@ class ExpansionController(MacroBehavior):
     )
     ```
 
-    Attributes
-    ----------
-    to_count : int
-        The target base count.
-    can_afford_check : bool = True
-        Check if we can afford expansion. Setting this to False
-        will allow the worker to move to a location ready to build
-        the expansion.
-    check_location_is_safe : bool = True
-        Check if we don't knowingly expand at a dangerous
-        location.
-    max_pending : int = 1
-        Maximum pending townhalls at any time.
-    prioritize : bool = False
-        Will return True for this behavior if we can't afford expansion.
+    Attributes:
+        to_count: The target base count.
+        can_afford_check: Check if we can afford expansion. Setting this to False
+            will allow the worker to move to a location ready to build the expansion.
+            Defaults to True.
+        check_location_is_safe: Check if we don't knowingly expand at a dangerous
+            location. Defaults to True.
+        max_pending: Maximum pending townhalls at any time. Defaults to 1.
+        prioritize: Will return True for this behavior if we can't afford expansion.
+            Default is False
     """
 
     to_count: int

--- a/src/ares/behaviors/macro/expansion_controller.py
+++ b/src/ares/behaviors/macro/expansion_controller.py
@@ -18,8 +18,6 @@ from ares.managers.manager_mediator import ManagerMediator
 class ExpansionController(MacroBehavior):
     """Manage expanding.
 
-    Examples
-    --------
     Example:
     ```py
     from ares.behaviors.macro import ExpansionController

--- a/src/ares/behaviors/macro/gas_building_controller.py
+++ b/src/ares/behaviors/macro/gas_building_controller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared, cy_sorted_by_distance_to
 from sc2.data import Race
@@ -39,7 +39,7 @@ class GasBuildingController(MacroBehavior):
 
     to_count: int
     max_pending: int = 1
-    closest_to: Optional[Point2] = None
+    closest_to: Point2 | None = None
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         num_gas: int

--- a/src/ares/behaviors/macro/gas_building_controller.py
+++ b/src/ares/behaviors/macro/gas_building_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -9,6 +10,7 @@ from sc2.units import Units
 
 if TYPE_CHECKING:
     from ares import AresBot
+
 from ares.behaviors.macro.macro_behavior import MacroBehavior
 from ares.managers.manager_mediator import ManagerMediator
 

--- a/src/ares/behaviors/macro/gas_building_controller.py
+++ b/src/ares/behaviors/macro/gas_building_controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -41,7 +42,7 @@ class GasBuildingController(MacroBehavior):
     max_pending: int = 1
     closest_to: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         num_gas: int
         if ai.race == Race.Terran:
             num_gas = ai.not_started_but_in_building_tracker(ai.gas_type) + len(

--- a/src/ares/behaviors/macro/macro_behavior.py
+++ b/src/ares/behaviors/macro/macro_behavior.py
@@ -18,18 +18,13 @@ class MacroBehavior(Behavior, Protocol):
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Parameters
-        ----------
-        ai : AresBot
-            Bot object that will be running the game.
-        config : dict
-            Dictionary with the data from the configuration file.
-        mediator : ManagerMediator
-            ManagerMediator used for getting information from other managers.
+        Args:
+            ai: Bot object that will be running the game.
+            config: Dictionary with the data from the configuration file.
+            mediator: ManagerMediator used for getting information from other managers.
 
-        Returns
-        -------
-        bool
-            MacroBehavior carried out an action.
+        Returns:
+            bool: MacroBehavior carried out an action.
+
         """
         ...

--- a/src/ares/behaviors/macro/macro_behavior.py
+++ b/src/ares/behaviors/macro/macro_behavior.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,19 +11,24 @@ if TYPE_CHECKING:
 class MacroBehavior(Behavior, Protocol):
     """Interface that all macro behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.
         No need to return anything for a macro behavior.
 
-        Args:
-            ai: Bot object that will be running the game.
-            config: Dictionary with the data from the configuration file.
-            mediator: ManagerMediator used for getting information from other managers.
+        Parameters
+        ----------
+        ai : AresBot
+            Bot object that will be running the game.
+        config : dict
+            Dictionary with the data from the configuration file.
+        mediator : ManagerMediator
+            ManagerMediator used for getting information from other managers.
 
-        Returns:
-            bool: MacroBehavior carried out an action.
-
+        Returns
+        -------
+        bool
+            MacroBehavior carried out an action.
         """
         ...

--- a/src/ares/behaviors/macro/macro_behavior.py
+++ b/src/ares/behaviors/macro/macro_behavior.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior

--- a/src/ares/behaviors/macro/macro_plan.py
+++ b/src/ares/behaviors/macro/macro_plan.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/macro_plan.py
+++ b/src/ares/behaviors/macro/macro_plan.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -45,7 +46,7 @@ class MacroPlan(Behavior):
     def add(self, behavior: MacroBehavior) -> None:
         self.macros.append(behavior)
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for macro in self.macros:
             if macro.execute(ai, config, mediator):
                 # executed a macro behavior

--- a/src/ares/behaviors/macro/mining.py
+++ b/src/ares/behaviors/macro/mining.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable
 

--- a/src/ares/behaviors/macro/mining.py
+++ b/src/ares/behaviors/macro/mining.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 from cython_extensions.units_utils import cy_sorted_by_distance_to
@@ -78,7 +78,7 @@ class Mining(MacroBehavior):
     vespene_boost: bool = False
     workers_per_gas: int = 3
     self_defence_active: bool = True
-    safe_long_distance_mineral_fields: Optional[Units] = None
+    safe_long_distance_mineral_fields: Units | None = None
     locked_action_tags: dict[int, float] = field(default_factory=dict)
     weight_safety_limit: float = 12.0
 
@@ -107,7 +107,7 @@ class Mining(MacroBehavior):
         worker_to_th: dict[int, int] = mediator.get_worker_tag_to_townhall_tag
         # for each mineral tag, get the position in front of the mineral
         min_target: dict[int, Point2] = mediator.get_mineral_target_dict
-        main_enemy_ground_threats: Optional[Units] = None
+        main_enemy_ground_threats: Units | None = None
         race: Race = ai.race
         if self.self_defence_active:
             main_enemy_ground_threats = mediator.get_main_ground_threats_near_townhall
@@ -115,8 +115,8 @@ class Mining(MacroBehavior):
         for worker in workers:
             worker_position: Point2 = worker.position
             worker_tag: int = worker.tag
-            resource: Optional[Unit] = None
-            resource_position: Optional[Point2] = None
+            resource: Unit | None = None
+            resource_position: Point2 | None = None
             resource_tag: int = -1
 
             assigned_mineral_patch: bool = worker_tag in worker_to_mineral_patch_dict
@@ -340,7 +340,7 @@ class Mining(MacroBehavior):
                 self._safe_long_distance_mineral_fields(ai, mediator)
             )
 
-        target_mineral: Optional[Unit] = None
+        target_mineral: Unit | None = None
 
         # on route to a far mineral patch
         if (

--- a/src/ares/behaviors/macro/mining.py
+++ b/src/ares/behaviors/macro/mining.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable
 
@@ -82,7 +83,7 @@ class Mining(MacroBehavior):
     locked_action_tags: dict[int, float] = field(default_factory=dict)
     weight_safety_limit: float = 12.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         workers: Units = mediator.get_units_from_role(
             role=UnitRole.GATHERING,
             unit_type=ai.worker_type,
@@ -94,16 +95,16 @@ class Mining(MacroBehavior):
         health_perc: float = self.flee_at_health_perc
         avoidance_grid: np.ndarray = mediator.get_ground_avoidance_grid
         grid: np.ndarray = mediator.get_ground_grid
-        mineral_patch_to_list_of_workers: dict[int, set[int]] = (
-            mediator.get_mineral_patch_to_list_of_workers
-        )
+        mineral_patch_to_list_of_workers: dict[
+            int, set[int]
+        ] = mediator.get_mineral_patch_to_list_of_workers
         path_find: Callable = mediator.find_path_next_point
         pos_safe: Callable = mediator.is_position_safe
         th_dist_factor: float = config[MINING][TOWNHALL_DISTANCE_FACTOR]
         worker_to_geyser_dict: dict[int, int] = mediator.get_worker_to_vespene_dict
-        worker_to_mineral_patch_dict: dict[int, int] = (
-            mediator.get_worker_to_mineral_patch_dict
-        )
+        worker_to_mineral_patch_dict: dict[
+            int, int
+        ] = mediator.get_worker_to_mineral_patch_dict
         worker_to_th: dict[int, int] = mediator.get_worker_tag_to_townhall_tag
         # for each mineral tag, get the position in front of the mineral
         min_target: dict[int, Point2] = mediator.get_mineral_target_dict
@@ -256,7 +257,7 @@ class Mining(MacroBehavior):
             mediator.find_closest_safe_spot(from_pos=worker.position, grid=grid)
         )
 
-    def _do_standard_mining(self, ai: "AresBot", worker: Unit, resource: Unit) -> None:
+    def _do_standard_mining(self, ai: AresBot, worker: Unit, resource: Unit) -> None:
         worker_tag: int = worker.tag
         # prevent spam clicking workers on patch to reduce APM
         if worker_tag in self.locked_action_tags:
@@ -297,7 +298,7 @@ class Mining(MacroBehavior):
 
     def _long_distance_mining(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         mediator: ManagerMediator,
         grid: np.ndarray,
         worker: Unit,
@@ -428,7 +429,7 @@ class Mining(MacroBehavior):
         Gather command and letting the SC2 engine manage the worker.
 
         Parameters:
-            ai: Main AresBot object
+            ai: AresBot
             distance_to_townhall_factor: Multiplier used for finding the target
                 of the Move command when returning resources.
             target: Mineral field or Townhall that the worker should be
@@ -479,12 +480,12 @@ class Mining(MacroBehavior):
 
     @staticmethod
     def _safe_long_distance_mineral_fields(
-        ai: "AresBot", mediator: ManagerMediator
+        ai: AresBot, mediator: ManagerMediator
     ) -> list[Unit]:
         """Find mineral fields for long distance miners.
 
         Parameters:
-            ai: Main AresBot object
+            ai: AresBot
             mediator: Manager mediator to interact with the managers
 
         Returns:
@@ -511,7 +512,7 @@ class Mining(MacroBehavior):
 
     @staticmethod
     def _worker_attacking_enemy(
-        ai: "AresBot", dist_to_resource: float, worker: Unit
+        ai: AresBot, dist_to_resource: float, worker: Unit
     ) -> bool:
         if not worker.is_collecting or dist_to_resource > 1.0:
             if enemies := cy_in_attack_range(worker, ai.enemy_units):

--- a/src/ares/behaviors/macro/production_controller.py
+++ b/src/ares/behaviors/macro/production_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/production_controller.py
+++ b/src/ares/behaviors/macro/production_controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -81,7 +82,7 @@ class ProductionController(MacroBehavior):
     should_repower_structures: bool = True
     max_production_structures: int = 12
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no need for anything else if zerg
         if ai.race == Race.Zerg:
             logger.warning(
@@ -231,7 +232,7 @@ class ProductionController(MacroBehavior):
 
     def _building_production_due_to_bank(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         unit_type_id: UnitTypeId,
         collection_rate_minerals: int,
         collection_rate_vespene: int,
@@ -285,7 +286,7 @@ class ProductionController(MacroBehavior):
         return False
 
     def is_flying_production(
-        self, ai: "AresBot", flying_structures: dict, train_from: set[UnitTypeId]
+        self, ai: AresBot, flying_structures: dict, train_from: set[UnitTypeId]
     ) -> bool:
         if ai.race == Race.Terran:
             prod_flying: bool = False
@@ -307,7 +308,7 @@ class ProductionController(MacroBehavior):
         return False
 
     def _add_techlab_to_existing(
-        self, ai: "AresBot", unit_type_id: UnitTypeId, researched_from_id
+        self, ai: AresBot, unit_type_id: UnitTypeId, researched_from_id
     ) -> bool:
         structures_dict: dict = ai.mediator.get_own_structures_dict
         build_techlab_from: UnitTypeId = BUILD_TECHLAB_FROM[researched_from_id]

--- a/src/ares/behaviors/macro/production_controller.py
+++ b/src/ares/behaviors/macro/production_controller.py
@@ -55,7 +55,7 @@ class ProductionController(MacroBehavior):
             with a priority integer for unit emphasis.
         base_location: The location where production should be built.
         add_production_at_bank: When the bank reaches this size, calculate what
-            extra production would be useful. Tuple where the first value is
+            extra production would be useful. `tuple` where the first value is
             minerals and the second is vespene. Defaults to `(300, 300)`.
         alpha: Controls how much production to add when the bank is higher than
             `add_production_at_bank`. Defaults to `0.9`.

--- a/src/ares/behaviors/macro/protoss_static_defence.py
+++ b/src/ares/behaviors/macro/protoss_static_defence.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/protoss_static_defence.py
+++ b/src/ares/behaviors/macro/protoss_static_defence.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -46,7 +47,7 @@ class ProtossStaticDefence(MacroBehavior):
     max_on_route: int = 1
     tech_base_location: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if ai.race != Race.Protoss:
             logger.warning(
                 f"{ai.time_formatted}: ProtossStaticDefence only supports Protoss."
@@ -123,7 +124,7 @@ class ProtossStaticDefence(MacroBehavior):
         return False
 
     def _tech_required(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator
+        self, ai: AresBot, config: dict, mediator: ManagerMediator
     ) -> bool:
         tech_location: Point2 = self.tech_base_location or ai.start_location
 

--- a/src/ares/behaviors/macro/restore_power.py
+++ b/src/ares/behaviors/macro/restore_power.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/restore_power.py
+++ b/src/ares/behaviors/macro/restore_power.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,7 @@ class RestorePower(MacroBehavior):
     ```
     """
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if structures_no_power := [
             s
             for s in ai.structures
@@ -89,7 +90,7 @@ class RestorePower(MacroBehavior):
 
     @staticmethod
     def _restoring_power(
-        structure: Unit, ai: "AresBot", config: dict, mediator: ManagerMediator
+        structure: Unit, ai: AresBot, config: dict, mediator: ManagerMediator
     ) -> bool:
         """Given an unpowered structure, find a pylon position.
 

--- a/src/ares/behaviors/macro/spawn_controller.py
+++ b/src/ares/behaviors/macro/spawn_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from math import isclose
 from typing import TYPE_CHECKING

--- a/src/ares/behaviors/macro/spawn_controller.py
+++ b/src/ares/behaviors/macro/spawn_controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from math import isclose
 from typing import TYPE_CHECKING
@@ -77,7 +78,7 @@ class SpawnController(MacroBehavior):
     __excluded_structure_tags: set[int] = field(default_factory=set)
     __supply_available: float = 0.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # allow gateways to morph before issuing commands
         if UpgradeId.WARPGATERESEARCH in ai.state.upgrades and [
             g
@@ -235,7 +236,7 @@ class SpawnController(MacroBehavior):
 
     def _add_to_build_dict(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         type_id: UnitTypeId,
         base_unit: list[Unit],
         amount: int,
@@ -270,7 +271,7 @@ class SpawnController(MacroBehavior):
 
     @staticmethod
     def _calculate_build_amount(
-        ai: "AresBot",
+        ai: AresBot,
         unit_type: UnitTypeId,
         base_units: list[Unit],
         supply_left: float,
@@ -305,14 +306,14 @@ class SpawnController(MacroBehavior):
         return amount, supply_cost, cost
 
     @staticmethod
-    def _can_afford(ai: "AresBot", unit_type_id: UnitTypeId) -> bool:
+    def _can_afford(ai: AresBot, unit_type_id: UnitTypeId) -> bool:
         if unit_type_id == UnitTypeId.ARCHON:
             return True
         return ai.can_afford(unit_type_id)
 
     @staticmethod
     def _handle_archon_morph(
-        ai: "AresBot", build_structures: list[Unit], mediator: ManagerMediator
+        ai: AresBot, build_structures: list[Unit], mediator: ManagerMediator
     ) -> None:
         unit_role_dict: dict[UnitRole, set] = mediator.get_unit_role_dict
         build_structures = [
@@ -326,7 +327,7 @@ class SpawnController(MacroBehavior):
         templar: list[Unit] = build_structures[:2]
         ai.request_archon_morph(templar)
 
-    def _morph_units(self, ai: "AresBot", mediator: ManagerMediator) -> bool:
+    def _morph_units(self, ai: AresBot, mediator: ManagerMediator) -> bool:
         did_action: bool = False
         for unit, value in self.__build_dict.items():
             did_action = True

--- a/src/ares/behaviors/macro/speed_mining.py
+++ b/src/ares/behaviors/macro/speed_mining.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/speed_mining.py
+++ b/src/ares/behaviors/macro/speed_mining.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_closest_to, cy_distance_to_squared, cy_towards
 from loguru import logger
@@ -47,11 +47,11 @@ class SpeedMining(CombatIndividualBehavior):
     """
 
     worker: Unit
-    target: Union[Point2, Unit]
+    target: Point2 | Unit
     worker_position: Point2
     resource_target_pos: Point2
     distance_to_townhall_factor: float = 1.08
-    townhall: Optional[Unit] = None
+    townhall: Unit | None = None
 
     def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
         if not ai.townhalls:

--- a/src/ares/behaviors/macro/speed_mining.py
+++ b/src/ares/behaviors/macro/speed_mining.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -53,7 +54,7 @@ class SpeedMining(CombatIndividualBehavior):
     distance_to_townhall_factor: float = 1.08
     townhall: Unit | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if not ai.townhalls:
             logger.warning(
                 f"{ai.time_formatted} Attempting to speed mine with no townhalls"

--- a/src/ares/behaviors/macro/tech_up.py
+++ b/src/ares/behaviors/macro/tech_up.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from sc2.dicts.unit_trained_from import UNIT_TRAINED_FROM
@@ -48,7 +48,7 @@ class TechUp(MacroBehavior):
 
     """
 
-    desired_tech: Union[UpgradeId, UnitTypeId]
+    desired_tech: UpgradeId | UnitTypeId
     base_location: Point2
     ignore_existing_techlabs: bool = False
 
@@ -192,7 +192,7 @@ class TechUp(MacroBehavior):
         base_location: Point2,
         researched_from_id: UnitTypeId,
         tech_required: list[UnitTypeId],
-        desired_tech: Union[UnitTypeId, UpgradeId],
+        desired_tech: UnitTypeId | UpgradeId,
         ignore_existing_techlabs: bool = False,
     ) -> bool:
         """

--- a/src/ares/behaviors/macro/tech_up.py
+++ b/src/ares/behaviors/macro/tech_up.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -52,7 +53,7 @@ class TechUp(MacroBehavior):
     base_location: Point2
     ignore_existing_techlabs: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert isinstance(
             self.desired_tech, (UpgradeId, UnitTypeId)
         ), f"Wrong type provided for `desired_tech`, got {type(self.desired_tech)}"
@@ -188,7 +189,7 @@ class TechUp(MacroBehavior):
 
     def _adding_techlab(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         base_location: Point2,
         researched_from_id: UnitTypeId,
         tech_required: list[UnitTypeId],
@@ -261,7 +262,7 @@ class TechUp(MacroBehavior):
                 return True
         return False
 
-    def _upgrade_zerg_townhall(self, structure_type: UnitTypeId, ai: "AresBot") -> bool:
+    def _upgrade_zerg_townhall(self, structure_type: UnitTypeId, ai: AresBot) -> bool:
         structures_dict = ai.mediator.get_own_structures_dict
         if (
             not ai.can_afford(structure_type)

--- a/src/ares/behaviors/macro/tech_up.py
+++ b/src/ares/behaviors/macro/tech_up.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -19,7 +20,7 @@ from ares.managers.manager_mediator import ManagerMediator
 if TYPE_CHECKING:
     from ares import AresBot
 
-BUILD_TECHLAB_FROM: dict[UnitTypeId:UnitTypeId] = {
+BUILD_TECHLAB_FROM: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.BARRACKSTECHLAB: UnitTypeId.BARRACKS,
     UnitTypeId.FACTORYTECHLAB: UnitTypeId.FACTORY,
     UnitTypeId.STARPORTTECHLAB: UnitTypeId.STARPORT,

--- a/src/ares/behaviors/macro/upgrade_ccs.py
+++ b/src/ares/behaviors/macro/upgrade_ccs.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/upgrade_ccs.py
+++ b/src/ares/behaviors/macro/upgrade_ccs.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -42,7 +43,7 @@ class UpgradeCCs(MacroBehavior):
     to: UnitTypeId
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         ccs: list[Unit] = [
             th
             for th in mediator.get_own_structures_dict[UnitTypeId.COMMANDCENTER]

--- a/src/ares/behaviors/macro/upgrade_controller.py
+++ b/src/ares/behaviors/macro/upgrade_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/ares/behaviors/macro/upgrade_controller.py
+++ b/src/ares/behaviors/macro/upgrade_controller.py
@@ -29,7 +29,6 @@ class UpgradeController(MacroBehavior):
     make the tech buildings required.
 
     Examples
-    --------
     ```py
     from ares.behaviors.macro import UpgradeController
     from sc2.ids.upgrade_id import UpgradeId
@@ -46,19 +45,16 @@ class UpgradeController(MacroBehavior):
     )
     ```
 
-    Attributes
-    ----------
-    upgrade_list : list[UpgradeId]
-        List of desired upgrades.
-    base_location : Point2, optional
-        Location to build upgrade buildings.
-    auto_tech_up_enabled : bool = True
-        Whether automatic tech building is enabled.
-    prioritize : bool = False
-        If True and there is an Upgrade ready to go, but
-        we can't afford it yet, this behavior will return True.
-        This is useful in a MacroPlan as it will prevent other
-        spending actions occurring.
+    Attributes:
+        upgrade_list: List of desired upgrades.
+        base_location: Location to build upgrade buildings.
+        auto_tech_up_enabled: bool
+        prioritize: If True and there is an Upgrade ready to go, but
+            we can't afford it yet, this behavior will return True.
+            This is useful in a MacroPlan as it will prevent other
+            spending actions occurring.
+            Default is False
+
     """
 
     upgrade_list: list[UpgradeId]

--- a/src/ares/behaviors/macro/upgrade_controller.py
+++ b/src/ares/behaviors/macro/upgrade_controller.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -26,8 +27,8 @@ class UpgradeController(MacroBehavior):
     currently researchable this behavior will automatically
     make the tech buildings required.
 
-
-    Example:
+    Examples
+    --------
     ```py
     from ares.behaviors.macro import UpgradeController
     from sc2.ids.upgrade_id import UpgradeId
@@ -44,16 +45,19 @@ class UpgradeController(MacroBehavior):
     )
     ```
 
-    Attributes:
-        upgrade_list: List of desired upgrades.
-        base_location: Location to build upgrade buildings.
-        auto_tech_up_enabled: bool
-        prioritize: If True and there is an Upgrade ready to go, but
-            we can't afford it yet, this behavior will return True.
-            This is useful in a MacroPlan as it will prevent other
-            spending actions occurring.
-            Default is False
-
+    Attributes
+    ----------
+    upgrade_list : list[UpgradeId]
+        List of desired upgrades.
+    base_location : Point2, optional
+        Location to build upgrade buildings.
+    auto_tech_up_enabled : bool = True
+        Whether automatic tech building is enabled.
+    prioritize : bool = False
+        If True and there is an Upgrade ready to go, but
+        we can't afford it yet, this behavior will return True.
+        This is useful in a MacroPlan as it will prevent other
+        spending actions occurring.
     """
 
     upgrade_list: list[UpgradeId]
@@ -61,7 +65,7 @@ class UpgradeController(MacroBehavior):
     auto_tech_up_enabled: bool = True
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for upgrade in self.upgrade_list:
             if ai.pending_or_complete_upgrade(upgrade):
                 continue

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -184,23 +184,18 @@ class BuildOrderParser:
         represent valid structure types before creating a lambda build step for
         execution.
 
-        Parameters
-        ----------
-        commands : list[str]
-            List of command parameters. The first two parameters are positional,
-            while the last two specify the structures involved in the addon swap.
+        Args:
+            commands (list[str]): List of command parameters.
+                The first two parameters are positional, while the last two
+                specify the structures involved in the addon swap.
 
-        Raises
-        ------
-        Exception
-            If the length of the `commands` list is not exactly 4.
-        ValueError
-            If any structure names provided in the `commands` are invalid.
+        Raises:
+            Exception: If the length of the `commands` list is not exactly 4.
+            ValueError: If any structure names provided in the `commands`
+                are invalid.
 
-        Returns
-        -------
-        Callable
-            A callable object that represents the constructed build step.
+        Returns:
+            Callable: A callable object that represents the constructed build step.
         """
         # ['21', 'addonswap', 'factory', 'barracksreactor']
         if len(commands) != 4:

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
@@ -43,7 +44,7 @@ class BuildOrderParser:
         parse: Parses the `raw_build_order` attribute into a list of `BuildOrderStep`.
     """
 
-    ai: "AresBot"
+    ai: AresBot
     build_order_step_dict: dict | None = None
 
     def __post_init__(self) -> None:
@@ -174,27 +175,31 @@ class BuildOrderParser:
 
     def _generate_addon_build_step(self, commands) -> Callable:
         # Non-standard attribute format to bypass PyCharm docstring completion quirks.
-        """
-        Generates a callable build step for executing an
+        """Generates a callable build step for executing an
         `AddonSwap` command in the build runner.
 
         The `AddonSwap` command allows structures to exchange addon components.
         This function validates the provided command arguments to ensure they
-        represent valid structure types
-        before creating a lambda build step for execution.
+        represent valid structure types before creating a lambda build step for
+        execution.
 
-        Args:
-            commands (list[str]): List of command parameters.
-                The first two parameters are positional, while the last two
-                specify the structures involved in the addon swap.
+        Parameters
+        ----------
+        commands : list[str]
+            List of command parameters. The first two parameters are positional,
+            while the last two specify the structures involved in the addon swap.
 
-        Raises:
-            Exception: If the length of the `commands` list is not exactly 4.
-            ValueError: If any structure names provided in the `commands`
-                are invalid.
+        Raises
+        ------
+        Exception
+            If the length of the `commands` list is not exactly 4.
+        ValueError
+            If any structure names provided in the `commands` are invalid.
 
-        Returns:
-            Callable: A callable object that represents the constructed build step.
+        Returns
+        -------
+        Callable
+            A callable object that represents the constructed build step.
         """
         # ['21', 'addonswap', 'factory', 'barracksreactor']
         if len(commands) != 4:
@@ -494,9 +499,9 @@ class BuildOrderParser:
                 # look behind natural
                 elif order_target == BuildOrderTargetOptions.NAT:
                     location: Point2 = self._get_target(order_target)
-                    behind_min_line_points: list[Point2] = (
-                        self.ai.mediator.get_behind_mineral_positions(th_pos=location)
-                    )
+                    behind_min_line_points: list[
+                        Point2
+                    ] = self.ai.mediator.get_behind_mineral_positions(th_pos=location)
                     for point in behind_min_line_points:
                         target_positions.append(point)
                 # otherwise just go to location
@@ -557,8 +562,10 @@ class BuildOrderParser:
         try:
             supply: int = int(commands[0])
         except ValueError:
-            logger.warning(f"""{raw_step} should begin with an integer supply count,
-                found {commands[0]}, setting supply target to 0""")
+            logger.warning(
+                f"""{raw_step} should begin with an integer supply count,
+                found {commands[0]}, setting supply target to 0"""
+            )
             supply: int = 0
 
         # this is the main command of a build order step (worker, gas, expand etc.)

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -85,7 +85,7 @@ class BuildOrderParser:
 
         Returns:
         --------
-        Dict
+        dict
             A dictionary of `BuildOrderStep` objects representing the recognized
             build order commands.
         """

--- a/src/ares/build_runner/build_order_runner.py
+++ b/src/ares/build_runner/build_order_runner.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared, cy_towards

--- a/src/ares/build_runner/build_order_runner.py
+++ b/src/ares/build_runner/build_order_runner.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared, cy_towards
@@ -80,7 +81,7 @@ class BuildOrderRunner:
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         chosen_opening: str,
         config: dict,
         mediator: ManagerMediator,
@@ -448,9 +449,9 @@ class BuildOrderRunner:
                     )
                     self.current_step_started = True
             elif command == BuildOrderOptions.OVERLORD_SCOUT:
-                unit_role_dict: dict[UnitRole, set[int]] = (
-                    self.mediator.get_unit_role_dict
-                )
+                unit_role_dict: dict[
+                    UnitRole, set[int]
+                ] = self.mediator.get_unit_role_dict
                 if overlords := [
                     ol
                     for ol in self.mediator.get_own_army_dict[UnitTypeId.OVERLORD]
@@ -632,10 +633,10 @@ class BuildOrderRunner:
                 if structure_type == self.ai.supply_type:
                     return list(self.ai.main_base_ramp.corner_depots)[0]
 
-            behind_mineral_line: list[Point2] = (
-                self.mediator.get_behind_mineral_positions(
-                    th_pos=self.ai.start_location
-                )
+            behind_mineral_line: list[
+                Point2
+            ] = self.mediator.get_behind_mineral_positions(
+                th_pos=self.ai.start_location
             )
             build_near: Point2 | None = None
             if structure_type not in {UnitTypeId.SPINECRAWLER, UnitTypeId.SPORECRAWLER}:

--- a/src/ares/build_runner/build_order_step.py
+++ b/src/ares/build_runner/build_order_step.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable
 

--- a/src/ares/cache.py
+++ b/src/ares/cache.py
@@ -1,4 +1,5 @@
 """Tools for caching attribute values."""
+from __future__ import annotations
 
 from functools import wraps
 

--- a/src/ares/chat_debug.py
+++ b/src/ares/chat_debug.py
@@ -2,6 +2,7 @@
 
 Feel free to add to this.
 """
+from __future__ import annotations
 
 from sc2.ids.unit_typeid import UnitTypeId
 from sc2.position import Point2

--- a/src/ares/config_parser.py
+++ b/src/ares/config_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from os import path

--- a/src/ares/config_parser.py
+++ b/src/ares/config_parser.py
@@ -29,7 +29,7 @@ class ConfigParser:
 
         Returns
         -------
-        Dict :
+        dict :
             Internal parsed config.yml by default, or the merged internal and
             users config files.
         """
@@ -81,7 +81,7 @@ class ConfigParser:
 
         Returns
         -------
-        Dict :
+        dict :
             A single config dictionary where user values override default values.
         """
         """Recursively merge override dictionary into default dictionary."""

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import List, Set
 
 from sc2.data import Race
 from sc2.ids.ability_id import AbilityId
@@ -118,7 +117,7 @@ WIN: str = "Win"
 ADD_SHADES_ON_FRAME: int = (
     120  #: The frame at which point Adept Shades are treated as units
 )
-BANNED_PHRASES: List[str] = [
+BANNED_PHRASES: list[str] = [
     "COCOON",
     "EGG",
     "CHANGELING",
@@ -146,15 +145,15 @@ LIGHTSHADE: str = "LIGHTSHADE"
 MAX_SNAPSHOTS_PER_UNIT: int = 10
 
 # chat debug
-COOLDOWN: Set[str] = {"COOLDOWN"}
-CREATE: Set[str] = {"CREATE", "MAKE"}
-FOOD: Set[str] = {"FOOD", "SUPPLY"}
-GOD: Set[str] = {"GOD"}
-KILL: Set[str] = {"DESTROY", "KILL"}
-RESOURCES: Set[str] = {"RESOURCES", "MONEY"}
-SHOW_MAP: Set[str] = {"REVEAL", "SHOW", "SHOW-MAP"}
-TECH_TREE: Set[str] = {"TECH", "TECH-TREE"}
-UPGRADES: Set[str] = {"UPGRADES"}
+COOLDOWN: set[str] = {"COOLDOWN"}
+CREATE: set[str] = {"CREATE", "MAKE"}
+FOOD: set[str] = {"FOOD", "SUPPLY"}
+GOD: set[str] = {"GOD"}
+KILL: set[str] = {"DESTROY", "KILL"}
+RESOURCES: set[str] = {"RESOURCES", "MONEY"}
+SHOW_MAP: set[str] = {"REVEAL", "SHOW", "SHOW-MAP"}
+TECH_TREE: set[str] = {"TECH", "TECH-TREE"}
+UPGRADES: set[str] = {"UPGRADES"}
 
 # Enums:
 
@@ -571,7 +570,7 @@ class WallOffDetection(Enum):
     DISTANCE = 3.5
 
 
-# Sets:
+# sets:
 
 REACTOR_TRAIN_ABILITIES: list[AbilityId] = [
     AbilityId.BARRACKSTRAIN_MARINE,
@@ -592,7 +591,7 @@ ADD_ONS: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.STARPORTTECHLAB: UnitTypeId.STARPORT,
 }
 
-ALL_PRODUCTION_STRUCTURES: Set[UnitTypeId] = {
+ALL_PRODUCTION_STRUCTURES: frozenset[UnitTypeId] = ({
     UnitTypeId.BARRACKS,
     UnitTypeId.FACTORY,
     UnitTypeId.STARPORT,
@@ -600,9 +599,9 @@ ALL_PRODUCTION_STRUCTURES: Set[UnitTypeId] = {
     UnitTypeId.WARPGATE,
     UnitTypeId.ROBOTICSFACILITY,
     UnitTypeId.STARGATE,
-}
+})
 
-ALL_STRUCTURES: Set[UnitTypeId] = {
+ALL_STRUCTURES: frozenset[UnitTypeId] = ({
     UnitTypeId.ARMORY,
     UnitTypeId.ASSIMILATOR,
     UnitTypeId.ASSIMILATORRICH,
@@ -686,9 +685,9 @@ ALL_STRUCTURES: Set[UnitTypeId] = {
     UnitTypeId.TWILIGHTCOUNCIL,
     UnitTypeId.ULTRALISKCAVERN,
     UnitTypeId.WARPGATE,
-}
+})
 
-BURROWED_ALIAS: Set[UnitTypeId] = {
+BURROWED_ALIAS: frozenset[UnitTypeId] = ({
     UnitTypeId.BANELINGBURROWED,
     UnitTypeId.CREEPTUMORBURROWED,
     UnitTypeId.DRONEBURROWED,
@@ -703,33 +702,33 @@ BURROWED_ALIAS: Set[UnitTypeId] = {
     UnitTypeId.ULTRALISKBURROWED,
     UnitTypeId.WIDOWMINEBURROWED,
     UnitTypeId.ZERGLINGBURROWED,
-}
+})
 
-CHANGELING_TYPES: Set[UnitTypeId] = {
+CHANGELING_TYPES: frozenset[UnitTypeId] =({
     UnitTypeId.CHANGELING,
     UnitTypeId.CHANGELINGZERGLING,
     UnitTypeId.CHANGELINGZERGLINGWINGS,
     UnitTypeId.CHANGELINGMARINE,
     UnitTypeId.CHANGELINGMARINESHIELD,
     UnitTypeId.CHANGELINGZEALOT,
-}
+})
 
-COMMON_UNIT_IGNORE_TYPES: set[UnitTypeId] = {
+COMMON_UNIT_IGNORE_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.EGG,
     UnitTypeId.LARVA,
     UnitTypeId.CREEPTUMORBURROWED,
     UnitTypeId.CREEPTUMORQUEEN,
     UnitTypeId.CREEPTUMOR,
     UnitTypeId.MULE,
-}
+})
 
-CREEP_TUMOR_TYPES: Set[UnitTypeId] = {
+CREEP_TUMOR_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.CREEPTUMOR,
     UnitTypeId.CREEPTUMORQUEEN,
     UnitTypeId.CREEPTUMORBURROWED,
-}
+})
 
-DETECTORS: Set[UnitTypeId | EffectId] = {
+DETECTORS: frozenset[UnitTypeId | EffectId] = ({
     UnitTypeId.OBSERVER,
     UnitTypeId.OBSERVERSIEGEMODE,
     UnitTypeId.PHOTONCANNON,
@@ -739,18 +738,18 @@ DETECTORS: Set[UnitTypeId | EffectId] = {
     UnitTypeId.OVERSEER,
     UnitTypeId.OVERSEERSIEGEMODE,
     UnitTypeId.SPORECRAWLER,
-}
+})
 
-DROP_ROLES: set[UnitRole] = {
+DROP_ROLES: frozenset[UnitRole] = ({
     UnitRole.DROP_SHIP,
     UnitRole.DROP_UNITS_TO_LOAD,
     UnitRole.DROP_UNITS_ATTACKING,
-}
+})
 
-EGG_BUTTON_NAMES: Set[str] = {"Drone", "Overlord"}
+EGG_BUTTON_NAMES: frozenset[str] = ({"Drone", "Overlord"})
 
 # we ignore these when detecting if an expansion location is blocked
-FLYING_IGNORE: Set[UnitTypeId] = {
+FLYING_IGNORE: frozenset[UnitTypeId] = ({
     UnitTypeId.OBSERVER,
     UnitTypeId.OVERLORD,
     UnitTypeId.OVERSEER,
@@ -760,28 +759,28 @@ FLYING_IGNORE: Set[UnitTypeId] = {
     UnitTypeId.FACTORYFLYING,
     UnitTypeId.STARPORTFLYING,
     UnitTypeId.PHOENIX,
-}
+})
 
-GAS_BUILDINGS = {
+GAS_BUILDINGS = frozenset[UnitTypeId] = ({
     UnitTypeId.ASSIMILATOR,
     UnitTypeId.EXTRACTOR,
     UnitTypeId.REFINERY,
     UnitTypeId.ASSIMILATORRICH,
     UnitTypeId.EXTRACTORRICH,
     UnitTypeId.REFINERYRICH,
-}
+})
 
-GATEWAY_UNITS: set[UnitTypeId] = {
+GATEWAY_UNITS: frozenset[UnitTypeId] = ({
     UnitTypeId.ZEALOT,
     UnitTypeId.ADEPT,
     UnitTypeId.STALKER,
     UnitTypeId.DARKTEMPLAR,
     UnitTypeId.HIGHTEMPLAR,
     UnitTypeId.SENTRY,
-}
+})
 
 # These are not really rocks, but end up in the destructible collection
-IGNORE_DESTRUCTABLES: Set[UnitTypeId] = {
+IGNORE_DESTRUCTABLES: set[UnitTypeId] = {
     UnitTypeId.INHIBITORZONESMALL,
     UnitTypeId.INHIBITORZONEFLYINGLARGE,
     UnitTypeId.INHIBITORZONEFLYINGMEDIUM,
@@ -797,7 +796,7 @@ IGNORE_DESTRUCTABLES: Set[UnitTypeId] = {
     UnitTypeId.CLEANINGBOT,
 }
 
-IGNORE_IN_COST_DICT: Set[UnitTypeId] = {
+IGNORE_IN_COST_DICT: frozenset[UnitTypeId] = ({
     UnitTypeId.BROODLING,
     UnitTypeId.INTERCEPTOR,
     UnitTypeId.LARVA,
@@ -811,24 +810,24 @@ IGNORE_IN_COST_DICT: Set[UnitTypeId] = {
     UnitTypeId.REFINERYRICH,
     UnitTypeId.ASSIMILATORRICH,
     UnitTypeId.EXTRACTORRICH,
-}
+})
 
-IGNORED_UNIT_TYPES_MEMORY_MANAGER: Set[UnitTypeId] = set()
+IGNORED_UNIT_TYPES_MEMORY_MANAGER: set[UnitTypeId] = set()
 
 # roles where most of our force is likely to be
-MAIN_COMBAT_ROLES: Set[UnitRole] = {
+MAIN_COMBAT_ROLES: set[UnitRole] = {
     UnitRole.ATTACKING,
     UnitRole.DEFENDING,
 }
 
-TECHLAB_TYPES: set[UnitTypeId] = {
+TECHLAB_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.BARRACKSTECHLAB,
     UnitTypeId.FACTORYTECHLAB,
     UnitTypeId.STARPORTTECHLAB,
     UnitTypeId.TECHLAB,
-}
+})
 
-TOWNHALL_TYPES: Set[UnitTypeId] = {
+TOWNHALL_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.HATCHERY,
     UnitTypeId.LAIR,
     UnitTypeId.HIVE,
@@ -838,9 +837,9 @@ TOWNHALL_TYPES: Set[UnitTypeId] = {
     UnitTypeId.ORBITALCOMMANDFLYING,
     UnitTypeId.PLANETARYFORTRESS,
     UnitTypeId.NEXUS,
-}
+})
 
-TOWNHALL_TYPES_NO_PF: Set[UnitTypeId] = {
+TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = ({
     UnitTypeId.HATCHERY,
     UnitTypeId.LAIR,
     UnitTypeId.HIVE,
@@ -849,9 +848,9 @@ TOWNHALL_TYPES_NO_PF: Set[UnitTypeId] = {
     UnitTypeId.ORBITALCOMMAND,
     UnitTypeId.ORBITALCOMMANDFLYING,
     UnitTypeId.NEXUS,
-}
+})
 
-UNITS_TO_AVOID_TYPES: Set[UnitTypeId] = {
+UNITS_TO_AVOID_TYPES: set[UnitTypeId] = ({
     UnitTypeId.CREEPTUMOR,
     UnitTypeId.CREEPTUMORBURROWED,
     UnitTypeId.CREEPTUMORQUEEN,
@@ -859,18 +858,24 @@ UNITS_TO_AVOID_TYPES: Set[UnitTypeId] = {
     UnitTypeId.INFESTORBURROWED,
     UnitTypeId.ROACHBURROWED,
     UnitTypeId.SPORECRAWLER,
-}
+})
 
-UNITS_TO_IGNORE: Set[UnitTypeId] = set()
-UNIT_TYPES_WITH_NO_ROLE: Set[UnitTypeId] = set()
-ALL_WORKER_TYPES: Set[UnitTypeId] = {
+UNITS_TO_IGNORE: set[UnitTypeId] = set()
+UNIT_TYPES_WITH_NO_ROLE: set[UnitTypeId] = set()
+
+WORKER_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.DRONE,
-    UnitTypeId.DRONEBURROWED,
-    UnitTypeId.MULE,
+    UnitTypeId.PROBE,
+    UnitTypeId.SCV
+})
+
+ALL_WORKER_TYPES: frozenset[UnitTypeId] = frozenset({
+    UnitTypeId.DRONE,
     UnitTypeId.PROBE,
     UnitTypeId.SCV,
-}
-WORKER_TYPES: Set[UnitTypeId] = {UnitTypeId.DRONE, UnitTypeId.PROBE, UnitTypeId.SCV}
+    UnitTypeId.DRONEBURROWED,
+    UnitTypeId.MULE,
+})
 
 RACE_SUPPLY: dict[Race, UnitTypeId] = {
     Race.Protoss: UnitTypeId.PYLON,
@@ -878,7 +883,7 @@ RACE_SUPPLY: dict[Race, UnitTypeId] = {
     Race.Zerg: UnitTypeId.OVERLORD,
 }
 
-REQUIRE_POWER_STRUCTURE_TYPES: set[UnitTypeId] = {
+REQUIRE_POWER_STRUCTURE_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.PHOTONCANNON,
     UnitTypeId.SHIELDBATTERY,
     UnitTypeId.GATEWAY,
@@ -892,48 +897,48 @@ REQUIRE_POWER_STRUCTURE_TYPES: set[UnitTypeId] = {
     UnitTypeId.FLEETBEACON,
     UnitTypeId.TWILIGHTCOUNCIL,
     UnitTypeId.DARKSHRINE,
-}
+})
 
-LOSS_EMPHATIC_OR_WORSE: Set[EngagementResult] = {EngagementResult.LOSS_EMPHATIC}
+LOSS_EMPHATIC_OR_WORSE: set[EngagementResult] = {EngagementResult.LOSS_EMPHATIC}
 
-LOSS_OVERWHELMING_OR_WORSE: Set[EngagementResult] = LOSS_EMPHATIC_OR_WORSE | {
+LOSS_OVERWHELMING_OR_WORSE: set[EngagementResult] = LOSS_EMPHATIC_OR_WORSE | {
     EngagementResult.LOSS_OVERWHELMING
 }
 
-LOSS_DECISIVE_OR_WORSE: Set[EngagementResult] = LOSS_OVERWHELMING_OR_WORSE | {
+LOSS_DECISIVE_OR_WORSE: set[EngagementResult] = LOSS_OVERWHELMING_OR_WORSE | {
     EngagementResult.LOSS_DECISIVE
 }
 
-LOSS_CLOSE_OR_WORSE: Set[EngagementResult] = LOSS_DECISIVE_OR_WORSE | {
+LOSS_CLOSE_OR_WORSE: set[EngagementResult] = LOSS_DECISIVE_OR_WORSE | {
     EngagementResult.LOSS_CLOSE
 }
 
-LOSS_MARGINAL_OR_WORSE: Set[EngagementResult] = LOSS_CLOSE_OR_WORSE | {
+LOSS_MARGINAL_OR_WORSE: set[EngagementResult] = LOSS_CLOSE_OR_WORSE | {
     EngagementResult.LOSS_MARGINAL
 }
 
-VICTORY_EMPHATIC_OR_BETTER: Set[EngagementResult] = {EngagementResult.VICTORY_EMPHATIC}
+VICTORY_EMPHATIC_OR_BETTER: set[EngagementResult] = {EngagementResult.VICTORY_EMPHATIC}
 
-VICTORY_OVERWHELMING_OR_BETTER: Set[EngagementResult] = VICTORY_EMPHATIC_OR_BETTER | {
+VICTORY_OVERWHELMING_OR_BETTER: set[EngagementResult] = VICTORY_EMPHATIC_OR_BETTER | {
     EngagementResult.VICTORY_OVERWHELMING
 }
 
-VICTORY_DECISIVE_OR_BETTER: Set[EngagementResult] = VICTORY_OVERWHELMING_OR_BETTER | {
+VICTORY_DECISIVE_OR_BETTER: set[EngagementResult] = VICTORY_OVERWHELMING_OR_BETTER | {
     EngagementResult.VICTORY_DECISIVE
 }
 
-VICTORY_CLOSE_OR_BETTER: Set[EngagementResult] = VICTORY_DECISIVE_OR_BETTER | {
+VICTORY_CLOSE_OR_BETTER: set[EngagementResult] = VICTORY_DECISIVE_OR_BETTER | {
     EngagementResult.VICTORY_CLOSE
 }
 
-VICTORY_MARGINAL_OR_BETTER: Set[EngagementResult] = VICTORY_CLOSE_OR_BETTER | {
+VICTORY_MARGINAL_OR_BETTER: set[EngagementResult] = VICTORY_CLOSE_OR_BETTER | {
     EngagementResult.VICTORY_MARGINAL
 }
 
-TIE_OR_BETTER: Set[EngagementResult] = VICTORY_MARGINAL_OR_BETTER | {
+TIE_OR_BETTER: set[EngagementResult] = VICTORY_MARGINAL_OR_BETTER | {
     EngagementResult.TIE
 }
 
-LOSS_MARGINAL_OR_BETTER: Set[EngagementResult] = TIE_OR_BETTER | {
+LOSS_MARGINAL_OR_BETTER: set[EngagementResult] = TIE_OR_BETTER | {
     EngagementResult.LOSS_MARGINAL
 }

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -572,6 +572,15 @@ class WallOffDetection(Enum):
 
 # sets:
 
+REACTOR_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKSREACTOR,
+        UnitTypeId.FACTORYREACTOR,
+        UnitTypeId.STARPORTREACTOR,
+        UnitTypeId.REACTOR,
+    }
+)
+
 REACTOR_TRAIN_ABILITIES: list[AbilityId] = [
     AbilityId.BARRACKSTRAIN_MARINE,
     AbilityId.BARRACKSTRAIN_REAPER,
@@ -582,6 +591,15 @@ REACTOR_TRAIN_ABILITIES: list[AbilityId] = [
     AbilityId.STARPORTTRAIN_LIBERATOR,
 ]
 
+TECHLAB_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKSTECHLAB,
+        UnitTypeId.FACTORYTECHLAB,
+        UnitTypeId.STARPORTTECHLAB,
+        UnitTypeId.TECHLAB,
+    }
+)
+
 ADD_ONS: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.BARRACKSREACTOR: UnitTypeId.BARRACKS,
     UnitTypeId.FACTORYREACTOR: UnitTypeId.FACTORY,
@@ -591,193 +609,215 @@ ADD_ONS: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.STARPORTTECHLAB: UnitTypeId.STARPORT,
 }
 
-ALL_PRODUCTION_STRUCTURES: frozenset[UnitTypeId] = ({
-    UnitTypeId.BARRACKS,
-    UnitTypeId.FACTORY,
-    UnitTypeId.STARPORT,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.WARPGATE,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.STARGATE,
-})
+ALL_PRODUCTION_STRUCTURES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKS,
+        UnitTypeId.FACTORY,
+        UnitTypeId.STARPORT,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.WARPGATE,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.STARGATE,
+    }
+)
 
-ALL_STRUCTURES: frozenset[UnitTypeId] = ({
-    UnitTypeId.ARMORY,
-    UnitTypeId.ASSIMILATOR,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.AUTOTURRET,
-    UnitTypeId.BANELINGNEST,
-    UnitTypeId.BARRACKS,
-    UnitTypeId.BARRACKSFLYING,
-    UnitTypeId.BARRACKSREACTOR,
-    UnitTypeId.BARRACKSTECHLAB,
-    UnitTypeId.BUNKER,
-    UnitTypeId.BYPASSARMORDRONE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CYBERNETICSCORE,
-    UnitTypeId.DARKSHRINE,
-    UnitTypeId.ELSECARO_COLONIST_HUT,
-    UnitTypeId.ENGINEERINGBAY,
-    UnitTypeId.EVOLUTIONCHAMBER,
-    UnitTypeId.EXTRACTOR,
-    UnitTypeId.EXTRACTORRICH,
-    UnitTypeId.FACTORY,
-    UnitTypeId.FACTORYFLYING,
-    UnitTypeId.FACTORYREACTOR,
-    UnitTypeId.FACTORYTECHLAB,
-    UnitTypeId.FLEETBEACON,
-    UnitTypeId.FORGE,
-    UnitTypeId.FUSIONCORE,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.GHOSTACADEMY,
-    UnitTypeId.GREATERSPIRE,
-    UnitTypeId.HATCHERY,
-    UnitTypeId.HIVE,
-    UnitTypeId.HYDRALISKDEN,
-    UnitTypeId.INFESTATIONPIT,
-    UnitTypeId.LAIR,
-    UnitTypeId.LURKERDENMP,
-    UnitTypeId.MEDIVACMENGSKACGLUESCREENDUMMY,
-    UnitTypeId.MISSILETURRET,
-    UnitTypeId.NEXUS,
-    UnitTypeId.NYDUSCANAL,
-    UnitTypeId.NYDUSCANALATTACKER,
-    UnitTypeId.NYDUSCANALCREEPER,
-    UnitTypeId.NYDUSNETWORK,
-    UnitTypeId.ORACLESTASISTRAP,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.PLANETARYFORTRESS,
-    UnitTypeId.POINTDEFENSEDRONE,
-    UnitTypeId.PYLON,
-    UnitTypeId.PYLONOVERCHARGED,
-    UnitTypeId.RAVENREPAIRDRONE,
-    UnitTypeId.REACTOR,
-    UnitTypeId.REFINERY,
-    UnitTypeId.REFINERYRICH,
-    UnitTypeId.RESOURCEBLOCKER,
-    UnitTypeId.ROACHWARREN,
-    UnitTypeId.ROBOTICSBAY,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.SENSORTOWER,
-    UnitTypeId.SHIELDBATTERY,
-    UnitTypeId.SIEGETANKMENGSKACGLUESCREENDUMMY,
-    UnitTypeId.SPAWNINGPOOL,
-    UnitTypeId.SPINECRAWLER,
-    UnitTypeId.SPINECRAWLERUPROOTED,
-    UnitTypeId.SPIRE,
-    UnitTypeId.SPORECRAWLER,
-    UnitTypeId.SPORECRAWLERUPROOTED,
-    UnitTypeId.STARGATE,
-    UnitTypeId.STARPORT,
-    UnitTypeId.STARPORTFLYING,
-    UnitTypeId.STARPORTREACTOR,
-    UnitTypeId.STARPORTTECHLAB,
-    UnitTypeId.SUPPLYDEPOT,
-    UnitTypeId.SUPPLYDEPOTLOWERED,
-    UnitTypeId.TECHLAB,
-    UnitTypeId.TEMPLARARCHIVE,
-    UnitTypeId.TWILIGHTCOUNCIL,
-    UnitTypeId.ULTRALISKCAVERN,
-    UnitTypeId.WARPGATE,
-})
+ALL_STRUCTURES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ARMORY,
+        UnitTypeId.ASSIMILATOR,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.AUTOTURRET,
+        UnitTypeId.BANELINGNEST,
+        UnitTypeId.BARRACKS,
+        UnitTypeId.BARRACKSFLYING,
+        UnitTypeId.BARRACKSREACTOR,
+        UnitTypeId.BARRACKSTECHLAB,
+        UnitTypeId.BUNKER,
+        UnitTypeId.BYPASSARMORDRONE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CYBERNETICSCORE,
+        UnitTypeId.DARKSHRINE,
+        UnitTypeId.ELSECARO_COLONIST_HUT,
+        UnitTypeId.ENGINEERINGBAY,
+        UnitTypeId.EVOLUTIONCHAMBER,
+        UnitTypeId.EXTRACTOR,
+        UnitTypeId.EXTRACTORRICH,
+        UnitTypeId.FACTORY,
+        UnitTypeId.FACTORYFLYING,
+        UnitTypeId.FACTORYREACTOR,
+        UnitTypeId.FACTORYTECHLAB,
+        UnitTypeId.FLEETBEACON,
+        UnitTypeId.FORGE,
+        UnitTypeId.FUSIONCORE,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.GHOSTACADEMY,
+        UnitTypeId.GREATERSPIRE,
+        UnitTypeId.HATCHERY,
+        UnitTypeId.HIVE,
+        UnitTypeId.HYDRALISKDEN,
+        UnitTypeId.INFESTATIONPIT,
+        UnitTypeId.LAIR,
+        UnitTypeId.LURKERDENMP,
+        UnitTypeId.MEDIVACMENGSKACGLUESCREENDUMMY,
+        UnitTypeId.MISSILETURRET,
+        UnitTypeId.NEXUS,
+        UnitTypeId.NYDUSCANAL,
+        UnitTypeId.NYDUSCANALATTACKER,
+        UnitTypeId.NYDUSCANALCREEPER,
+        UnitTypeId.NYDUSNETWORK,
+        UnitTypeId.ORACLESTASISTRAP,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.PLANETARYFORTRESS,
+        UnitTypeId.POINTDEFENSEDRONE,
+        UnitTypeId.PYLON,
+        UnitTypeId.PYLONOVERCHARGED,
+        UnitTypeId.RAVENREPAIRDRONE,
+        UnitTypeId.REACTOR,
+        UnitTypeId.REFINERY,
+        UnitTypeId.REFINERYRICH,
+        UnitTypeId.RESOURCEBLOCKER,
+        UnitTypeId.ROACHWARREN,
+        UnitTypeId.ROBOTICSBAY,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.SENSORTOWER,
+        UnitTypeId.SHIELDBATTERY,
+        UnitTypeId.SIEGETANKMENGSKACGLUESCREENDUMMY,
+        UnitTypeId.SPAWNINGPOOL,
+        UnitTypeId.SPINECRAWLER,
+        UnitTypeId.SPINECRAWLERUPROOTED,
+        UnitTypeId.SPIRE,
+        UnitTypeId.SPORECRAWLER,
+        UnitTypeId.SPORECRAWLERUPROOTED,
+        UnitTypeId.STARGATE,
+        UnitTypeId.STARPORT,
+        UnitTypeId.STARPORTFLYING,
+        UnitTypeId.STARPORTREACTOR,
+        UnitTypeId.STARPORTTECHLAB,
+        UnitTypeId.SUPPLYDEPOT,
+        UnitTypeId.SUPPLYDEPOTLOWERED,
+        UnitTypeId.TECHLAB,
+        UnitTypeId.TEMPLARARCHIVE,
+        UnitTypeId.TWILIGHTCOUNCIL,
+        UnitTypeId.ULTRALISKCAVERN,
+        UnitTypeId.WARPGATE,
+    }
+)
 
-BURROWED_ALIAS: frozenset[UnitTypeId] = ({
-    UnitTypeId.BANELINGBURROWED,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.DRONEBURROWED,
-    UnitTypeId.HYDRALISKBURROWED,
-    UnitTypeId.INFESTORBURROWED,
-    UnitTypeId.INFESTORTERRANBURROWED,
-    UnitTypeId.LURKERMPBURROWED,
-    UnitTypeId.QUEENBURROWED,
-    UnitTypeId.RAVAGERBURROWED,
-    UnitTypeId.ROACHBURROWED,
-    UnitTypeId.SWARMHOSTBURROWEDMP,
-    UnitTypeId.ULTRALISKBURROWED,
-    UnitTypeId.WIDOWMINEBURROWED,
-    UnitTypeId.ZERGLINGBURROWED,
-})
+BURROWED_ALIAS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BANELINGBURROWED,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.DRONEBURROWED,
+        UnitTypeId.HYDRALISKBURROWED,
+        UnitTypeId.INFESTORBURROWED,
+        UnitTypeId.INFESTORTERRANBURROWED,
+        UnitTypeId.LURKERMPBURROWED,
+        UnitTypeId.QUEENBURROWED,
+        UnitTypeId.RAVAGERBURROWED,
+        UnitTypeId.ROACHBURROWED,
+        UnitTypeId.SWARMHOSTBURROWEDMP,
+        UnitTypeId.ULTRALISKBURROWED,
+        UnitTypeId.WIDOWMINEBURROWED,
+        UnitTypeId.ZERGLINGBURROWED,
+    }
+)
 
-CHANGELING_TYPES: frozenset[UnitTypeId] =({
-    UnitTypeId.CHANGELING,
-    UnitTypeId.CHANGELINGZERGLING,
-    UnitTypeId.CHANGELINGZERGLINGWINGS,
-    UnitTypeId.CHANGELINGMARINE,
-    UnitTypeId.CHANGELINGMARINESHIELD,
-    UnitTypeId.CHANGELINGZEALOT,
-})
+CHANGELING_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.CHANGELING,
+        UnitTypeId.CHANGELINGZERGLING,
+        UnitTypeId.CHANGELINGZERGLINGWINGS,
+        UnitTypeId.CHANGELINGMARINE,
+        UnitTypeId.CHANGELINGMARINESHIELD,
+        UnitTypeId.CHANGELINGZEALOT,
+    }
+)
 
-COMMON_UNIT_IGNORE_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.EGG,
-    UnitTypeId.LARVA,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.MULE,
-})
+COMMON_UNIT_IGNORE_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.EGG,
+        UnitTypeId.LARVA,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.MULE,
+    }
+)
 
-CREEP_TUMOR_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CREEPTUMORBURROWED,
-})
+CREEP_TUMOR_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CREEPTUMORBURROWED,
+    }
+)
 
-DETECTORS: frozenset[UnitTypeId | EffectId] = ({
-    UnitTypeId.OBSERVER,
-    UnitTypeId.OBSERVERSIEGEMODE,
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.RAVEN,
-    UnitTypeId.MISSILETURRET,
-    EffectId.SCANNERSWEEP,
-    UnitTypeId.OVERSEER,
-    UnitTypeId.OVERSEERSIEGEMODE,
-    UnitTypeId.SPORECRAWLER,
-})
+DETECTORS: frozenset[UnitTypeId | EffectId] = frozenset(
+    {
+        UnitTypeId.OBSERVER,
+        UnitTypeId.OBSERVERSIEGEMODE,
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.RAVEN,
+        UnitTypeId.MISSILETURRET,
+        EffectId.SCANNERSWEEP,
+        UnitTypeId.OVERSEER,
+        UnitTypeId.OVERSEERSIEGEMODE,
+        UnitTypeId.SPORECRAWLER,
+    }
+)
 
-DROP_ROLES: frozenset[UnitRole] = ({
-    UnitRole.DROP_SHIP,
-    UnitRole.DROP_UNITS_TO_LOAD,
-    UnitRole.DROP_UNITS_ATTACKING,
-})
+DROP_ROLES: frozenset[UnitRole] = frozenset(
+    {
+        UnitRole.DROP_SHIP,
+        UnitRole.DROP_UNITS_TO_LOAD,
+        UnitRole.DROP_UNITS_ATTACKING,
+    }
+)
 
-EGG_BUTTON_NAMES: frozenset[str] = ({"Drone", "Overlord"})
+EGG_BUTTON_NAMES: frozenset[str] = frozenset({"Drone", "Overlord"})
 
 # we ignore these when detecting if an expansion location is blocked
-FLYING_IGNORE: frozenset[UnitTypeId] = ({
-    UnitTypeId.OBSERVER,
-    UnitTypeId.OVERLORD,
-    UnitTypeId.OVERSEER,
-    UnitTypeId.BARRACKSFLYING,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.FACTORYFLYING,
-    UnitTypeId.STARPORTFLYING,
-    UnitTypeId.PHOENIX,
-})
+FLYING_IGNORE: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.OBSERVER,
+        UnitTypeId.OVERLORD,
+        UnitTypeId.OVERSEER,
+        UnitTypeId.BARRACKSFLYING,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.FACTORYFLYING,
+        UnitTypeId.STARPORTFLYING,
+        UnitTypeId.PHOENIX,
+    }
+)
 
-GAS_BUILDINGS: frozenset[UnitTypeId] = ({
-    UnitTypeId.ASSIMILATOR,
-    UnitTypeId.EXTRACTOR,
-    UnitTypeId.REFINERY,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.EXTRACTORRICH,
-    UnitTypeId.REFINERYRICH,
-})
+GAS_BUILDINGS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ASSIMILATOR,
+        UnitTypeId.EXTRACTOR,
+        UnitTypeId.REFINERY,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.EXTRACTORRICH,
+        UnitTypeId.REFINERYRICH,
+    }
+)
 
-GATEWAY_UNITS: frozenset[UnitTypeId] = ({
-    UnitTypeId.ZEALOT,
-    UnitTypeId.ADEPT,
-    UnitTypeId.STALKER,
-    UnitTypeId.DARKTEMPLAR,
-    UnitTypeId.HIGHTEMPLAR,
-    UnitTypeId.SENTRY,
-})
+GATEWAY_UNITS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ZEALOT,
+        UnitTypeId.ADEPT,
+        UnitTypeId.STALKER,
+        UnitTypeId.DARKTEMPLAR,
+        UnitTypeId.HIGHTEMPLAR,
+        UnitTypeId.SENTRY,
+    }
+)
 
 # These are not really rocks, but end up in the destructible collection
 IGNORE_DESTRUCTABLES: set[UnitTypeId] = {
@@ -796,21 +836,23 @@ IGNORE_DESTRUCTABLES: set[UnitTypeId] = {
     UnitTypeId.CLEANINGBOT,
 }
 
-IGNORE_IN_COST_DICT: frozenset[UnitTypeId] = ({
-    UnitTypeId.BROODLING,
-    UnitTypeId.INTERCEPTOR,
-    UnitTypeId.LARVA,
-    UnitTypeId.LOCUSTMP,
-    UnitTypeId.LOCUSTMPFLYING,
-    UnitTypeId.MULE,
-    UnitTypeId.POINTDEFENSEDRONE,
-    UnitTypeId.INFESTEDTERRANSEGG,
-    UnitTypeId.INFESTEDTERRAN,
-    UnitTypeId.INFESTORBURROWED,
-    UnitTypeId.REFINERYRICH,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.EXTRACTORRICH,
-})
+IGNORE_IN_COST_DICT: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BROODLING,
+        UnitTypeId.INTERCEPTOR,
+        UnitTypeId.LARVA,
+        UnitTypeId.LOCUSTMP,
+        UnitTypeId.LOCUSTMPFLYING,
+        UnitTypeId.MULE,
+        UnitTypeId.POINTDEFENSEDRONE,
+        UnitTypeId.INFESTEDTERRANSEGG,
+        UnitTypeId.INFESTEDTERRAN,
+        UnitTypeId.INFESTORBURROWED,
+        UnitTypeId.REFINERYRICH,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.EXTRACTORRICH,
+    }
+)
 
 IGNORED_UNIT_TYPES_MEMORY_MANAGER: set[UnitTypeId] = set()
 
@@ -820,35 +862,33 @@ MAIN_COMBAT_ROLES: set[UnitRole] = {
     UnitRole.DEFENDING,
 }
 
-TECHLAB_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.BARRACKSTECHLAB,
-    UnitTypeId.FACTORYTECHLAB,
-    UnitTypeId.STARPORTTECHLAB,
-    UnitTypeId.TECHLAB,
-})
 
-TOWNHALL_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.HATCHERY,
-    UnitTypeId.LAIR,
-    UnitTypeId.HIVE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.PLANETARYFORTRESS,
-    UnitTypeId.NEXUS,
-})
+TOWNHALL_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.HATCHERY,
+        UnitTypeId.LAIR,
+        UnitTypeId.HIVE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.PLANETARYFORTRESS,
+        UnitTypeId.NEXUS,
+    }
+)
 
-TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = ({
-    UnitTypeId.HATCHERY,
-    UnitTypeId.LAIR,
-    UnitTypeId.HIVE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.NEXUS,
-})
+TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.HATCHERY,
+        UnitTypeId.LAIR,
+        UnitTypeId.HIVE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.NEXUS,
+    }
+)
 
 UNITS_TO_AVOID_TYPES: set[UnitTypeId] = ({
     UnitTypeId.CREEPTUMOR,
@@ -863,19 +903,23 @@ UNITS_TO_AVOID_TYPES: set[UnitTypeId] = ({
 UNITS_TO_IGNORE: set[UnitTypeId] = set()
 UNIT_TYPES_WITH_NO_ROLE: set[UnitTypeId] = set()
 
-WORKER_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.DRONE,
-    UnitTypeId.PROBE,
-    UnitTypeId.SCV
-})
+WORKER_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.DRONE,
+        UnitTypeId.PROBE,
+        UnitTypeId.SCV,
+    }
+)
 
-ALL_WORKER_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.DRONE,
-    UnitTypeId.PROBE,
-    UnitTypeId.SCV,
-    UnitTypeId.DRONEBURROWED,
-    UnitTypeId.MULE,
-})
+ALL_WORKER_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.DRONE,
+        UnitTypeId.PROBE,
+        UnitTypeId.SCV,
+        UnitTypeId.DRONEBURROWED,
+        UnitTypeId.MULE,
+    }
+)
 
 RACE_SUPPLY: dict[Race, UnitTypeId] = {
     Race.Protoss: UnitTypeId.PYLON,
@@ -883,21 +927,23 @@ RACE_SUPPLY: dict[Race, UnitTypeId] = {
     Race.Zerg: UnitTypeId.OVERLORD,
 }
 
-REQUIRE_POWER_STRUCTURE_TYPES: frozenset[UnitTypeId] = ({
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.SHIELDBATTERY,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.WARPGATE,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.ROBOTICSBAY,
-    UnitTypeId.STARGATE,
-    UnitTypeId.CYBERNETICSCORE,
-    UnitTypeId.FORGE,
-    UnitTypeId.TEMPLARARCHIVE,
-    UnitTypeId.FLEETBEACON,
-    UnitTypeId.TWILIGHTCOUNCIL,
-    UnitTypeId.DARKSHRINE,
-})
+REQUIRE_POWER_STRUCTURE_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.SHIELDBATTERY,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.WARPGATE,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.ROBOTICSBAY,
+        UnitTypeId.STARGATE,
+        UnitTypeId.CYBERNETICSCORE,
+        UnitTypeId.FORGE,
+        UnitTypeId.TEMPLARARCHIVE,
+        UnitTypeId.FLEETBEACON,
+        UnitTypeId.TWILIGHTCOUNCIL,
+        UnitTypeId.DARKSHRINE,
+    }
+)
 
 LOSS_EMPHATIC_OR_WORSE: set[EngagementResult] = {EngagementResult.LOSS_EMPHATIC}
 

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -921,7 +921,7 @@ ALL_WORKER_TYPES: frozenset[UnitTypeId] = frozenset(
     }
 )
 
-RACE_SUPPLY: dict[Race, UnitTypeId] = {
+RACE_SUPPLY: dict[Race.ValueType, UnitTypeId] = {
     Race.Protoss: UnitTypeId.PYLON,
     Race.Terran: UnitTypeId.SUPPLYDEPOT,
     Race.Zerg: UnitTypeId.OVERLORD,

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -890,7 +890,7 @@ TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = frozenset(
     }
 )
 
-UNITS_TO_AVOID_TYPES: set[UnitTypeId] = ({
+UNITS_TO_AVOID_TYPES: set[UnitTypeId] = {
     UnitTypeId.CREEPTUMOR,
     UnitTypeId.CREEPTUMORBURROWED,
     UnitTypeId.CREEPTUMORQUEEN,
@@ -898,7 +898,7 @@ UNITS_TO_AVOID_TYPES: set[UnitTypeId] = ({
     UnitTypeId.INFESTORBURROWED,
     UnitTypeId.ROACHBURROWED,
     UnitTypeId.SPORECRAWLER,
-})
+}
 
 UNITS_TO_IGNORE: set[UnitTypeId] = set()
 UNIT_TYPES_WITH_NO_ROLE: set[UnitTypeId] = set()

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -761,7 +761,7 @@ FLYING_IGNORE: frozenset[UnitTypeId] = ({
     UnitTypeId.PHOENIX,
 })
 
-GAS_BUILDINGS = frozenset[UnitTypeId] = ({
+GAS_BUILDINGS: frozenset[UnitTypeId] = ({
     UnitTypeId.ASSIMILATOR,
     UnitTypeId.EXTRACTOR,
     UnitTypeId.REFINERY,
@@ -869,7 +869,7 @@ WORKER_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.SCV
 })
 
-ALL_WORKER_TYPES: frozenset[UnitTypeId] = frozenset({
+ALL_WORKER_TYPES: frozenset[UnitTypeId] = ({
     UnitTypeId.DRONE,
     UnitTypeId.PROBE,
     UnitTypeId.SCV,

--- a/src/ares/custom_bot_ai.py
+++ b/src/ares/custom_bot_ai.py
@@ -1,5 +1,7 @@
 """Extension of sc2.BotAI to add custom functions."""
 
+from __future__ import annotations
+
 import argparse
 
 import numpy as np

--- a/src/ares/custom_bot_ai.py
+++ b/src/ares/custom_bot_ai.py
@@ -1,7 +1,6 @@
 """Extension of sc2.BotAI to add custom functions."""
 
 import argparse
-from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from cython_extensions import cy_closer_than, cy_distance_to_squared
@@ -143,7 +142,7 @@ class CustomBotAI(BotAI):
         )
 
     @staticmethod
-    def get_total_supply(units: Union[Units, list[Unit]]) -> int:
+    def get_total_supply(units: Units | list[Unit]) -> int:
         """Get total supply of units.
 
         Parameters
@@ -216,8 +215,8 @@ class CustomBotAI(BotAI):
         return False
 
     def split_ground_fliers(
-        self, units: Union[Units, list[Unit]], return_as_lists: bool = False
-    ) -> Union[Tuple[Units, Units], Tuple[list, list]]:
+        self, units: Units | list[Unit], return_as_lists: bool = False
+    ) -> tuple[Units | Units, tuple[list, list]]:
         """Split units into ground units and flying units.
 
         Parameters
@@ -227,8 +226,8 @@ class CustomBotAI(BotAI):
         return_as_lists :
         Returns
         -------
-        Tuple[Units, Units] :
-            Tuple where the first element is the ground units present in `Units` and
+        tuple[Units, Units] :
+            `tuple` where the first element is the ground units present in `Units` and
             the second element is the flying units present in `Units`
 
         """
@@ -290,8 +289,8 @@ class CustomBotAI(BotAI):
     async def _give_units_same_order(
         self,
         order: AbilityId,
-        unit_tags: Union[List[int], set[int]],
-        target: Optional[Union[Point2, Unit, int]] = None,
+        unit_tags: list[int] | set[int],
+        target: int | Point2 | Unit | None = None,
     ) -> None:  # pragma: no cover
         """
         Give units corresponding to the given tags the same order.
@@ -520,7 +519,7 @@ class CustomBotAI(BotAI):
         grid: np.ndarray,
         lower_threshold: float,
         upper_threshold: float,
-        color: Tuple[int, int, int],
+        color: tuple[int, int, int],
         size: int,
     ) -> None:
         height: float = self.get_terrain_z_height(self.game_info.map_center)

--- a/src/ares/dicts/ability_cooldowns.py
+++ b/src/ares/dicts/ability_cooldowns.py
@@ -1,5 +1,7 @@
 """Ability base cooldowns."""
 
+from __future__ import annotations
+
 from sc2.ids.ability_id import AbilityId
 
 # in frames

--- a/src/ares/dicts/ability_cooldowns.py
+++ b/src/ares/dicts/ability_cooldowns.py
@@ -1,11 +1,9 @@
 """Ability base cooldowns."""
 
-from typing import Dict
-
 from sc2.ids.ability_id import AbilityId
 
 # in frames
-ABILITY_FRAME_COOL_DOWN: Dict = {
+ABILITY_FRAME_COOL_DOWN: dict = {
     # Protoss
     AbilityId.ADEPTPHASESHIFT_ADEPTPHASESHIFT: int(22.4 * 11) + 6,
     AbilityId.BEHAVIOR_PULSARBEAMON: int(22.4 * 4) + 6,

--- a/src/ares/dicts/aoe_ability_to_range.py
+++ b/src/ares/dicts/aoe_ability_to_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.ability_id import AbilityId
 from sc2.ids.buff_id import BuffId
 from sc2.ids.effect_id import EffectId

--- a/src/ares/dicts/cost_dict.py
+++ b/src/ares/dicts/cost_dict.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.game_data import Cost
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/does_not_use_larva.py
+++ b/src/ares/dicts/does_not_use_larva.py
@@ -1,5 +1,7 @@
 """Zerg units that do not use Larva."""
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # key is the unit to build, value is the unit it builds from

--- a/src/ares/dicts/does_not_use_larva.py
+++ b/src/ares/dicts/does_not_use_larva.py
@@ -1,11 +1,9 @@
 """Zerg units that do not use Larva."""
 
-from typing import Dict
-
 from sc2.ids.unit_typeid import UnitTypeId
 
 # key is the unit to build, value is the unit it builds from
-DOES_NOT_USE_LARVA: Dict[UnitTypeId, UnitTypeId] = {
+DOES_NOT_USE_LARVA: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.BANELING: UnitTypeId.ZERGLING,
     UnitTypeId.BROODLORD: UnitTypeId.CORRUPTOR,
     UnitTypeId.LURKERMP: UnitTypeId.HYDRALISK,

--- a/src/ares/dicts/enemy_detector_ranges.py
+++ b/src/ares/dicts/enemy_detector_ranges.py
@@ -5,12 +5,10 @@ detectors will not be in range if they use these values.
 
 """
 
-from typing import Dict, Union
-
 from sc2.ids.effect_id import EffectId
 from sc2.ids.unit_typeid import UnitTypeId
 
-DETECTOR_RANGES: Dict[Union[EffectId, UnitTypeId], float] = {
+DETECTOR_RANGES: dict[EffectId | UnitTypeId, float] = {
     # technically it's their range + radius + 1 (for safety)
     # Protoss
     UnitTypeId.OBSERVER: 11 + 0.5 + 1,

--- a/src/ares/dicts/enemy_detector_ranges.py
+++ b/src/ares/dicts/enemy_detector_ranges.py
@@ -5,6 +5,8 @@ detectors will not be in range if they use these values.
 
 """
 
+from __future__ import annotations
+
 from sc2.ids.effect_id import EffectId
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/enemy_vs_ground_static_defense_ranges.py
+++ b/src/ares/dicts/enemy_vs_ground_static_defense_ranges.py
@@ -4,12 +4,10 @@ Includes some offset, plus opinions on Planetary Fortresses.
 
 """
 
-from typing import Dict
-
 from sc2.ids.unit_typeid import UnitTypeId
 
 # value is the range plus some offset
-ENEMY_VS_GROUND_STATIC_DEFENSE_TYPES: Dict[UnitTypeId, int] = {
+ENEMY_VS_GROUND_STATIC_DEFENSE_TYPES: dict[UnitTypeId, int] = {
     # Protoss
     UnitTypeId.PHOTONCANNON: 7 + 1,
     # Terran

--- a/src/ares/dicts/pickup_range.py
+++ b/src/ares/dicts/pickup_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # TODO: Correct these

--- a/src/ares/dicts/structure_to_building_size.py
+++ b/src/ares/dicts/structure_to_building_size.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 from ares.consts import BuildingSize

--- a/src/ares/dicts/turn_rate.py
+++ b/src/ares/dicts/turn_rate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/turn_rate.py
+++ b/src/ares/dicts/turn_rate.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 import numpy as np
 from sc2.ids.unit_typeid import UnitTypeId
 
 # movement turn rate
-TURN_RATE: Dict[UnitTypeId, float] = {
+TURN_RATE: dict[UnitTypeId, float] = {
     UnitTypeId.BALL: 720.0,
     UnitTypeId.COLOSSUS: np.inf,
     UnitTypeId.INFESTORTERRAN: 999.8437,

--- a/src/ares/dicts/unit_alias.py
+++ b/src/ares/dicts/unit_alias.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # similar to python-sc2 version, but with modifications for use in

--- a/src/ares/dicts/unit_data.py
+++ b/src/ares/dicts/unit_data.py
@@ -1,13 +1,11 @@
 """Mineral, gas, supply, and army values for units."""
 
-from typing import Dict
-
 from sc2.ids.unit_typeid import UnitTypeId
 
 # army_value = (((minerals / 0.9) + gas) * supply) / 50
 # with some edits where appropriate
 # Zerg building data includes Drone cost
-UNIT_DATA: Dict[UnitTypeId, Dict] = {
+UNIT_DATA: dict[UnitTypeId, dict] = {
     # these first 2 entries are rich vespene buildings?
     # on patch 5.0.14 AIE maps
     UnitTypeId.SIEGETANKMENGSKACGLUESCREENDUMMY: {

--- a/src/ares/dicts/unit_data.py
+++ b/src/ares/dicts/unit_data.py
@@ -1,5 +1,7 @@
 """Mineral, gas, supply, and army values for units."""
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # army_value = (((minerals / 0.9) + gas) * supply) / 50

--- a/src/ares/dicts/unit_tech_requirement.py
+++ b/src/ares/dicts/unit_tech_requirement.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 UNIT_TECH_REQUIREMENT: dict[UnitTypeId, list[UnitTypeId]] = dict(

--- a/src/ares/dicts/weight_costs.py
+++ b/src/ares/dicts/weight_costs.py
@@ -5,6 +5,8 @@ values are taken from the API for some units.
 
 """
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # Zerg building data includes Drone cost

--- a/src/ares/dicts/weight_costs.py
+++ b/src/ares/dicts/weight_costs.py
@@ -5,12 +5,10 @@ values are taken from the API for some units.
 
 """
 
-from typing import Dict
-
 from sc2.ids.unit_typeid import UnitTypeId
 
 # Zerg building data includes Drone cost
-WEIGHT_COSTS: Dict[UnitTypeId, Dict] = {
+WEIGHT_COSTS: dict[UnitTypeId, dict] = {
     UnitTypeId.ADEPT: {"AirCost": 0, "GroundCost": 9, "AirRange": 0, "GroundRange": 5},
     UnitTypeId.ADEPTPHASESHIFT: {
         "AirCost": 0,

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -1,7 +1,6 @@
 import sys
 from collections import defaultdict
 from os import getcwd, path
-from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 from cython_extensions import cy_towards, cy_unit_pending
@@ -66,7 +65,7 @@ class AresBot(CustomBotAI):
 
     behavior_executioner: BehaviorExecutioner  # executes behaviors on each step
     build_order_runner: BuildOrderRunner  # execute exact build order from config
-    cost_dict: Dict[UnitTypeId, Cost]  #: UnitTypeId to cost for faster lookup later
+    cost_dict: dict[UnitTypeId, Cost]  #: UnitTypeId to cost for faster lookup later
 
     NYDUSES: set[UnitTypeId] = {UnitTypeId.NYDUSCANAL, UnitTypeId.NYDUSNETWORK}
     UNIT_TYPES_NOT_IN_SLIM: set[UnitTypeId] = {
@@ -81,7 +80,7 @@ class AresBot(CustomBotAI):
         UnitTypeId.CREEPTUMORQUEEN,
     }
 
-    def __init__(self, game_step_override: Optional[int] = None):  # pragma: no cover
+    def __init__(self, game_step_override: int | None = None):  # pragma: no cover
         """Load config and set up necessary attributes.
 
         Parameters
@@ -112,7 +111,7 @@ class AresBot(CustomBotAI):
 
         self.config = config_parser.parse()
 
-        self.game_step_override: Optional[int] = game_step_override
+        self.game_step_override: int | None = game_step_override
         self.unit_tag_dict: dict[int, Unit] = {}
         self.chat_debug = None
         self.forcefield_to_bile_dict: dict[Point2, int] = {}
@@ -120,8 +119,8 @@ class AresBot(CustomBotAI):
 
         # track adept shades as we only add them towards shade completion (160 frames)
         # Key: tag of shade Value: frame shade commenced (+32 if no adept owner found)
-        self.adept_shades: DefaultDict[int, Dict] = defaultdict(dict)
-        self.adept_tags_with_shades_assigned: Set[int] = set()
+        self.adept_shades: defaultdict[int, dict] = defaultdict(dict)
+        self.adept_tags_with_shades_assigned: set[int] = set()
         # we skip python-sc2 iterations in realtime, so we keep track of our own one
         self.actual_iteration: int = 0
         self.WORKER_TYPES = WORKER_TYPES | {UnitTypeId.DRONEBURROWED}
@@ -129,7 +128,7 @@ class AresBot(CustomBotAI):
         self.num_larva_left: int = 0
 
         self._same_order_actions: list[
-            tuple[AbilityId, set[int], Optional[Union[Unit, Point2]]]
+            tuple[AbilityId, set[int], Point2 | Unit | None]
         ] = []
         self._drop_unload_actions: list[tuple[int, int]] = []
         self._archon_morph_actions: list[list] = []
@@ -141,17 +140,17 @@ class AresBot(CustomBotAI):
     def give_same_action(
         self,
         order: AbilityId,
-        unit_tags: Union[List[int], set[int]],
-        target: Optional[Union[Point2, int]] = None,
+        unit_tags: list[int] | set[int],
+        target: int | Point2 | None = None,
     ) -> None:
         self._same_order_actions.append((order, unit_tags, target))
 
     def do_unload_container(self, container_tag: int, index: int = 0) -> None:
         self._drop_unload_actions.append((container_tag, index))
 
-    def calculate_cost(self, item_id: Union[UnitTypeId, UpgradeId, AbilityId]) -> Cost:
+    def calculate_cost(self, item_id: AbilityId| UnitTypeId | UpgradeId) -> (Cost):
         if isinstance(item_id, UnitTypeId):
-            cost_dict: Dict[UnitTypeId, Cost] = getattr(self, "cost_dict", COST_DICT)
+            cost_dict: dict[UnitTypeId, Cost] = getattr(self, "cost_dict", COST_DICT)
             if item_id in cost_dict:
                 return cost_dict[item_id]
 
@@ -193,8 +192,8 @@ class AresBot(CustomBotAI):
         update_managers: bool = hasattr(self, "manager_hub")
         self._reset_variables()
         # there's going to be a lot of appending, so form Units at the end
-        batteries_list: List[Unit] = []
-        cannons_list: List[Unit] = []
+        batteries_list: list[Unit] = []
+        cannons_list: list[Unit] = []
         enemy_vs_ground_static_defense_list = []
         self._clear_adept_shades()
 
@@ -355,7 +354,7 @@ class AresBot(CustomBotAI):
 
             self.chat_debug = ChatDebug(self)
 
-        self.cost_dict: Dict[UnitTypeId, Cost] = COST_DICT
+        self.cost_dict: dict[UnitTypeId, Cost] = COST_DICT
 
     def register_managers(self) -> None:
         """Register standard and custom managers.
@@ -565,13 +564,13 @@ class AresBot(CustomBotAI):
 
     def _add_enemy_unit(
         self,
-        batteries_list: List[Unit],
-        cannons_list: List[Unit],
-        enemy_vs_ground_static_defense_list: List[Unit],
+        batteries_list: list[Unit],
+        cannons_list: list[Unit],
+        enemy_vs_ground_static_defense_list: list[Unit],
         unit_obj: Unit,
         update_managers: bool,
         unit_id: UnitTypeId,
-    ) -> Tuple[List, List, List]:
+    ) -> tuple[list, list, list]:
         """Add a given enemy unit to the appropriate objects
 
         Parameters
@@ -721,8 +720,8 @@ class AresBot(CustomBotAI):
         None
         """
         current_frame: int = self.state.game_loop
-        shade_owner_tags_to_remove: List[int] = []
-        keys_to_remove: List[int] = []
+        shade_owner_tags_to_remove: list[int] = []
+        keys_to_remove: list[int] = []
         for shade_tag, item in self.adept_shades.items():
             frame_shade_started: int = item[SHADE_COMMENCED]
             adept_owner: int = item[SHADE_OWNER]
@@ -825,12 +824,12 @@ class AresBot(CustomBotAI):
         self.all_gas_buildings = Units([], self)
         self.eggs: Units = Units([], self)
         self.unit_tag_dict = {}
-        self.overcharged_battery: Optional[Unit] = None
+        self.overcharged_battery: Unit | None = None
         self.nyduses = Units([], self)
-        self.enemy_detectors: List[Unit] = []
+        self.enemy_detectors: list[Unit] = []
         self.enemy_vs_ground_static_defense: Units = Units([], self)
-        self.friendly_parasitic_bomb_positions: List[Point2] = []
-        self.enemy_parasitic_bomb_positions: List[Point2] = []
+        self.friendly_parasitic_bomb_positions: list[Point2] = []
+        self.enemy_parasitic_bomb_positions: list[Point2] = []
 
         self._drop_unload_actions = []
         self._same_order_actions = []
@@ -908,7 +907,7 @@ class AresBot(CustomBotAI):
             Use to prevent selecting idle build structures that
             have already got a pending order this frame.
             Key: Unit that should get order, value: what UnitTypeId to build
-        ignored_build_from_tags : Set[int]
+        ignored_build_from_tags : set[int]
             Pass in if you don't want certain build structures selected.
 
         Returns
@@ -938,7 +937,7 @@ class AresBot(CustomBotAI):
             if structure_type == UnitTypeId.LARVA:
                 using_larva = True
 
-            build_from: Union[Units, list[Unit]] = build_from_dict[structure_type]
+            build_from: list[Unit] | Units = build_from_dict[structure_type]
             # only add if warpgate is off cooldown
             if structure_type == UnitTypeId.WARPGATE:
                 build_from = [

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections import defaultdict
 from os import getcwd, path

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -150,7 +150,7 @@ class AresBot(CustomBotAI):
     def do_unload_container(self, container_tag: int, index: int = 0) -> None:
         self._drop_unload_actions.append((container_tag, index))
 
-    def calculate_cost(self, item_id: AbilityId| UnitTypeId | UpgradeId) -> (Cost):
+    def calculate_cost(self, item_id: AbilityId | UnitTypeId | UpgradeId) -> (Cost):
         if isinstance(item_id, UnitTypeId):
             cost_dict: dict[UnitTypeId, Cost] = getattr(self, "cost_dict", COST_DICT)
             if item_id in cost_dict:

--- a/src/ares/managers/ability_tracker_manager.py
+++ b/src/ares/managers/ability_tracker_manager.py
@@ -1,6 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.ids.ability_id import AbilityId
@@ -19,14 +20,13 @@ if TYPE_CHECKING:
 class AbilityTrackerManager(Manager, IManagerMediator):
     """Manager to handle manually tracking abilities of units.
 
-    Attributes
-    ----------
-    ability_frame_cd_dict : dict
-        Dictionary with the cooldown of
-        usable abilities for faster lookup.
-    unit_to_ability_dict : dict
-        Dictionary of the unit tag to a
-        dictionary of each Ability and when it was last used.
+    Attributes:
+        ability_frame_cd_dict: Dictionary with the cooldown of
+            usable abilities for faster lookup.
+        unit_to_ability_dict: Dictionary of the unit tag to a
+            dictionary of each Ability and when it was last used.
+
+
     """
 
     def __init__(
@@ -39,12 +39,16 @@ class AbilityTrackerManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai : AresBot
+        ai :
             Bot object that will be running the game
-        config : dict
+        config :
             Dictionary with the data from the configuration file
-        mediator : ManagerMediator
+        mediator :
             ManagerMediator used for getting information from other managers.
+
+        Returns
+        -------
+
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -69,7 +73,7 @@ class AbilityTrackerManager(Manager, IManagerMediator):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 
@@ -242,6 +246,10 @@ class AbilityTrackerManager(Manager, IManagerMediator):
             The AbilityId that was used.
         unit_tag :
             The tag of the Unit that used the ability
+
+        Returns
+        -------
+
         """
         current_frame: int = self.ai.state.game_loop
         if unit_tag in self.unit_to_ability_dict:

--- a/src/ares/managers/ability_tracker_manager.py
+++ b/src/ares/managers/ability_tracker_manager.py
@@ -1,6 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
-from typing import TYPE_CHECKING, Dict, Optional
+from __future__ import annotations
+from typing import TYPE_CHECKING
 
 from sc2.ids.ability_id import AbilityId
 from sc2.ids.unit_typeid import UnitTypeId
@@ -18,13 +19,14 @@ if TYPE_CHECKING:
 class AbilityTrackerManager(Manager, IManagerMediator):
     """Manager to handle manually tracking abilities of units.
 
-    Attributes:
-        ability_frame_cd_dict: Dictionary with the cooldown of
-            usable abilities for faster lookup.
-        unit_to_ability_dict: Dictionary of the unit tag to a
-            dictionary of each Ability and when it was last used.
-
-
+    Attributes
+    ----------
+    ability_frame_cd_dict : dict
+        Dictionary with the cooldown of
+        usable abilities for faster lookup.
+    unit_to_ability_dict : dict
+        Dictionary of the unit tag to a
+        dictionary of each Ability and when it was last used.
     """
 
     def __init__(
@@ -37,16 +39,12 @@ class AbilityTrackerManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -244,10 +242,6 @@ class AbilityTrackerManager(Manager, IManagerMediator):
             The AbilityId that was used.
         unit_tag :
             The tag of the Unit that used the ability
-
-        Returns
-        -------
-
         """
         current_frame: int = self.ai.state.game_loop
         if unit_tag in self.unit_to_ability_dict:

--- a/src/ares/managers/ability_tracker_manager.py
+++ b/src/ares/managers/ability_tracker_manager.py
@@ -29,8 +29,8 @@ class AbilityTrackerManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
-        config: Dict,
+        ai: AresBot,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -61,10 +61,10 @@ class AbilityTrackerManager(Manager, IManagerMediator):
             ),
         }
         # make a copy, so we don't mess with anything when updating Medivac cds
-        self.ability_frame_cd_dict: Dict[AbilityId, int] = (
-            ABILITY_FRAME_COOL_DOWN.copy()
-        )
-        self.unit_to_ability_dict: Dict[int, Dict[AbilityId, int]] = {}
+        self.ability_frame_cd_dict: dict[
+            AbilityId, int
+        ] = ABILITY_FRAME_COOL_DOWN.copy()
+        self.unit_to_ability_dict: dict[int, dict[AbilityId, int]] = {}
 
     def manager_request(
         self,
@@ -72,7 +72,7 @@ class AbilityTrackerManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -89,7 +89,7 @@ class AbilityTrackerManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Dict] :
+        dict | None :
             Either one of the ability dictionaries is being returned or a function that
             returns None was called from a different manager (please don't do that).
 

--- a/src/ares/managers/building_manager.py
+++ b/src/ares/managers/building_manager.py
@@ -1,6 +1,7 @@
 """Handle the construction of buildings."""
 
 from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 

--- a/src/ares/managers/building_manager.py
+++ b/src/ares/managers/building_manager.py
@@ -1,17 +1,7 @@
 """Handle the construction of buildings."""
 
 from collections import defaultdict
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Coroutine,
-    DefaultDict,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Coroutine
 
 from cython_extensions import (
     cy_center,
@@ -59,17 +49,16 @@ class BuildingManager(Manager, IManagerMediator):
 
     Attributes
     ----------
-    blocked_expansion_locations : Set[Point2]
+    blocked_expansion_locations : set[Point2]
         Which expansion locations are blocked and not considered for expanding
-    building_tracker : Dict[int, Dict[str, Union[Point2, Unit, UnitTypeId], float]
+    building_tracker : dict[int, dict[str, Point2 | Unit | UnitTypeId, float]
         Tracks the worker tag to:
             UnitTypeId of the building to be built
             Point2 of where the building is to be placed
             In-game time when the order started
             Why the building is being built
-    building_counter : DefaultDict[UnitTypeId, int]
+    building_counter : defaultdict[UnitTypeId, int]
         Tracks the type of building in the tracker and how many are present
-
     """
 
     BUILDING_WORKER_TIMEOUT: float = 120.0
@@ -78,6 +67,7 @@ class BuildingManager(Manager, IManagerMediator):
         self,
         ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -112,13 +102,13 @@ class BuildingManager(Manager, IManagerMediator):
             ),
         }
 
-        self.building_tracker: Dict[
-            int, Dict[str, Union[Point2, Unit, UnitTypeId], float]
+        self.building_tracker: dict[
+            int, dict[str, Point2 | Unit | UnitTypeId, float]
         ] = {}
-        self.building_counter: DefaultDict[UnitTypeId, int] = defaultdict(int)
+        self.building_counter: defaultdict[UnitTypeId, int] = defaultdict(int)
         # remember for each expansion attempt, otherwise we lose memory
         # should be cleared after expanding
-        self.blocked_expansion_locations: Set[Point2] = set()
+        self.blocked_expansion_locations: set[Point2] = set()
 
     def manager_request(
         self,
@@ -126,7 +116,7 @@ class BuildingManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]]:
+    ) -> dict | defaultdict | Coroutine[Any, Any, bool] | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -143,9 +133,8 @@ class BuildingManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
+        dict | defaultdict | Coroutine[Any, Any, bool] | None :
             Everything that could possibly be returned from the Manager fits in there
-
         """
         return self.manager_requests_dict[request](kwargs)
 
@@ -252,7 +241,7 @@ class BuildingManager(Manager, IManagerMediator):
                 tags_to_remove.add(worker_tag)
                 continue
 
-            target: Union[Point2, Unit] = self.building_tracker[worker_tag][TARGET]
+            target: Point2 | Unit = self.building_tracker[worker_tag][TARGET]
             worker = self.ai.unit_tag_dict.get(worker_tag, None)
 
             if not worker:
@@ -277,7 +266,7 @@ class BuildingManager(Manager, IManagerMediator):
             building_spots.add(target)
             distance: float = 3.2 if structure_id in GAS_BUILDINGS else 1.0
             # if terran, check for unfinished structure
-            existing_unfinished_structure: Optional[Unit] = None
+            existing_unfinished_structure: Unit | None = None
             if self.ai.race == Race.Terran and structure_id in structures_dict:
                 if existing_unfinished_structures := [
                     s
@@ -321,7 +310,7 @@ class BuildingManager(Manager, IManagerMediator):
                     continue
 
             if cy_distance_to(worker.position, target.position) > distance:
-                order_target: Union[int, Point2, None] = worker.order_target
+                order_target: int | Point2 | None = worker.order_target
                 point: Point2 = self.manager_mediator.find_path_next_point(
                     start=worker.position,
                     target=target.position,
@@ -399,7 +388,7 @@ class BuildingManager(Manager, IManagerMediator):
                 self.manager_mediator.assign_role(tag=tag, role=UnitRole.GATHERING)
 
         for tag in dead_tags_to_remove:
-            position: Optional[Point2] = self.building_tracker[tag][TARGET]
+            position: Point2 | None = self.building_tracker[tag][TARGET]
             # some how there is no position
             # removing will allow this to be readded if required
             if not position:
@@ -431,7 +420,7 @@ class BuildingManager(Manager, IManagerMediator):
         Returns
         -------
         list[Point2] :
-            List of all target positions/units from the building tracker.
+            `list` of all target positions/units from the building tracker.
         """
         return [
             (
@@ -481,7 +470,7 @@ class BuildingManager(Manager, IManagerMediator):
             self.manager_mediator.assign_role(tag=tag, role=UnitRole.GATHERING)
 
     async def construct_gas(
-        self, max_building: int = 1, geyser: Optional[Unit] = None
+        self, max_building: int = 1, geyser: Unit | None = None
     ) -> None:
         """Build a gas building.
 
@@ -495,7 +484,7 @@ class BuildingManager(Manager, IManagerMediator):
         geyser :
             The geyser to build the gas building on
         """
-        pending_geysers: List[Unit] = [
+        pending_geysers: list[Unit] = [
             self.building_tracker[tag][TARGET]
             for tag in self.building_tracker
             if self.building_tracker[tag][ID] == self.ai.gas_type
@@ -507,7 +496,7 @@ class BuildingManager(Manager, IManagerMediator):
         if len(pending_geysers) + len(building_gases) >= max_building:
             return
 
-        target_geyser: Optional[Unit] = None
+        target_geyser: Unit | None = None
 
         if geyser:
             target_geyser = geyser
@@ -606,7 +595,7 @@ class BuildingManager(Manager, IManagerMediator):
 
     async def find_valid_position(
         self, building: UnitTypeId, pos: Point2
-    ) -> Union[Point2, Coroutine[Any, Any, Optional[Point2]]]:
+    ) -> Point2 | Coroutine[Any, Any, Point2 | None]:
         """Make sure multiple workers aren't trying to build in the same position.
 
         Notes
@@ -621,7 +610,7 @@ class BuildingManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Union[Point2, Coroutine[Any, Any, Optional[Point2]]] :
+        Point2 | Coroutine[Any, Any, Point2 | None] :
             Either a Point2 that's a valid placement or a position in the main base.
 
         """
@@ -640,7 +629,7 @@ class BuildingManager(Manager, IManagerMediator):
         self,
         worker: Unit,
         structure_type: UnitTypeId,
-        pos: Union[Point2, Unit],
+        pos: Point2 | Unit,
         assign_role: bool = True,
         building_purpose: BuildingPurpose = BuildingPurpose.NORMAL_BUILDING,
     ) -> bool:

--- a/src/ares/managers/building_manager.py
+++ b/src/ares/managers/building_manager.py
@@ -1,5 +1,6 @@
 """Handle the construction of buildings."""
 
+from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 
@@ -65,8 +66,7 @@ class BuildingManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -74,16 +74,12 @@ class BuildingManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(BuildingManager, self).__init__(ai, config, mediator)
 
@@ -145,10 +141,6 @@ class BuildingManager(Manager, IManagerMediator):
         ----------
         iteration :
             The current game iteration.
-
-        Returns
-        -------
-
         """
         self._handle_construction_orders()
 
@@ -215,9 +207,9 @@ class BuildingManager(Manager, IManagerMediator):
         """
         dead_tags_to_remove: set[int] = set()
         tags_to_remove: set[int] = set()
-        structures_dict: dict[UnitTypeId, Units] = (
-            self.manager_mediator.get_own_structures_dict
-        )
+        structures_dict: dict[
+            UnitTypeId, Units
+        ] = self.manager_mediator.get_own_structures_dict
 
         building_spots: set[Point2] = set()
 
@@ -340,9 +332,9 @@ class BuildingManager(Manager, IManagerMediator):
                         if available_geysers := self.ai.vespene_geyser.filter(
                             lambda g: not existing_gas_buildings.closer_than(5.0, g)
                         ):
-                            self.building_tracker[worker_tag][TARGET] = (
-                                available_geysers.closest_to(self.ai.start_location)
-                            )
+                            self.building_tracker[worker_tag][
+                                TARGET
+                            ] = available_geysers.closest_to(self.ai.start_location)
                             continue
                     else:
                         # this to fix the occasional bug where despite build gas action
@@ -366,11 +358,11 @@ class BuildingManager(Manager, IManagerMediator):
                         if self.ai.race == Race.Zerg:
                             tags_to_remove.add(worker_tag)
                         else:
-                            self.building_tracker[worker_tag][TARGET] = (
-                                self.manager_mediator.request_building_placement(
-                                    base_location=self.ai.start_location,
-                                    structure_type=structure_id,
-                                )
+                            self.building_tracker[worker_tag][
+                                TARGET
+                            ] = self.manager_mediator.request_building_placement(
+                                base_location=self.ai.start_location,
+                                structure_type=structure_id,
                             )
                         continue
 
@@ -605,8 +597,8 @@ class BuildingManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        building
-        pos
+        building : UnitTypeId
+        pos : Point2
 
         Returns
         -------

--- a/src/ares/managers/combat_sim_manager.py
+++ b/src/ares/managers/combat_sim_manager.py
@@ -14,6 +14,7 @@ WARNING:
 """
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from sc2.units import Units

--- a/src/ares/managers/combat_sim_manager.py
+++ b/src/ares/managers/combat_sim_manager.py
@@ -13,6 +13,7 @@ WARNING:
     - IDPTG/Paul
 """
 
+from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from sc2.units import Units
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 class CombatSimManager(Manager, IManagerMediator):
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -37,11 +38,11 @@ class CombatSimManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(CombatSimManager, self).__init__(ai, config, mediator)

--- a/src/ares/managers/creep_manager.py
+++ b/src/ares/managers/creep_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from typing import Any
 

--- a/src/ares/managers/creep_manager.py
+++ b/src/ares/managers/creep_manager.py
@@ -88,7 +88,7 @@ class CreepManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[BotMode, List[BotMode]]] :
+        BotMode | list[BotMode] | None :
             Either one of the ability dictionaries is being returned or a function that
             returns None was called from a different manager (please don't do that).
 
@@ -475,7 +475,7 @@ class CreepManager(Manager, IManagerMediator):
         return pos
 
     def _get_overlord_creep_spotter_positions(
-        self, overlords: Units | list[Unit], target_pos: Point2
+        self, overlords: list[Unit] | Units , target_pos: Point2
     ) -> dict[int, Point2]:
         """Find optimal positions for overlords to provide vision for creep spread.
 

--- a/src/ares/managers/creep_manager.py
+++ b/src/ares/managers/creep_manager.py
@@ -477,7 +477,7 @@ class CreepManager(Manager, IManagerMediator):
         return pos
 
     def _get_overlord_creep_spotter_positions(
-        self, overlords: list[Unit] | Units , target_pos: Point2
+        self, overlords: list[Unit] | Units, target_pos: Point2
     ) -> dict[int, Point2]:
         """Find optimal positions for overlords to provide vision for creep spread.
 

--- a/src/ares/managers/creep_manager.py
+++ b/src/ares/managers/creep_manager.py
@@ -161,9 +161,9 @@ class CreepManager(Manager, IManagerMediator):
 
     @property_cache_once_per_frame
     def existing_tumor_positions_or_order_targets(self) -> list[Point2]:
-        own_structures_dict: dict[UnitTypeId, Units] = (
-            self.manager_mediator.get_own_structures_dict
-        )
+        own_structures_dict: dict[
+            UnitTypeId, Units
+        ] = self.manager_mediator.get_own_structures_dict
         positions: list[Point2] = [
             u.position
             for creep_tumor_type in CREEP_TUMOR_TYPES
@@ -332,11 +332,11 @@ class CreepManager(Manager, IManagerMediator):
                         ):
                             too_close = True
 
-                        own_ths: list[Unit] = (
-                            self.manager_mediator.get_own_structures_dict[
-                                UnitTypeId.HATCHERY
-                            ]
-                        )
+                        own_ths: list[
+                            Unit
+                        ] = self.manager_mediator.get_own_structures_dict[
+                            UnitTypeId.HATCHERY
+                        ]
                         # can act a bit weird near pending hatchery, avoid it
                         if not all(
                             cy_distance_to_squared(creep_pos, townhall.position)
@@ -482,13 +482,15 @@ class CreepManager(Manager, IManagerMediator):
         This function finds the edge of creep and distributes
         overlord positions evenly around it.
 
-        Parameters:
-            overlords : Units | list[Unit]
-                The overlords that will be positioned for creep vision
+        Parameters
+        ----------
+        overlords : list[Unit] | Units
+            The overlords that will be positioned for creep vision.
 
-        Returns:
-            dict[int: Point2]
-                Dictionary mapping overlord tag to position where it should move
+        Returns
+        -------
+        dict[int: Point2]
+            Dictionary mapping overlord tag to position where it should move.
         """
         if not overlords:
             return {}

--- a/src/ares/managers/data_manager.py
+++ b/src/ares/managers/data_manager.py
@@ -4,7 +4,6 @@ import json
 import os
 from collections import defaultdict, deque
 from os import path
-from typing import Dict, List, Optional, Union
 
 from loguru import logger
 from sc2.data import Result
@@ -38,16 +37,16 @@ class DataManager(Manager, IManagerMediator):
 
     Attributes
     ----------
-    manager_requests_dict : Dict[ManagerRequestType, Callable[[Any]]
+    manager_requests_dict : dict[ManagerRequestType, Callable[[Any]]
         A dictionary of functions that can be requested by other managers.
     chosen_opening : str
         The chosen opening strategy for the current match.
-    build_cycle : List[str]
+    build_cycle : list[str]
         A list of available build strategies for the bot.
     found_build : bool
         A boolean flag indicating if the opponent's build strategy from the previous
         game was found in the build cycle.
-    opponent_history : List
+    opponent_history : list
         A list containing the bot's previous match history against the current opponent.
     file_path : str
         The file path of the json file containing the opponent's match history.
@@ -62,7 +61,7 @@ class DataManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Optional[Union[str, list[str]]]:
+    ) -> str | list[str] | None:
         Fetch information from this Manager so another Manager can use it.
 
     initialise(self) -> None:
@@ -74,17 +73,17 @@ class DataManager(Manager, IManagerMediator):
     _choose_opening(self) -> None:
         Choose the opening strategy for the bot based on the opponent's previous game.
 
-    _get_build_cycle(self) -> List[str]:
+    _get_build_cycle(self) -> list[str]:
         Get the list of available build strategies for the bot.
 
     _get_opponent_data(self, _opponent_id: str) -> None:
         Load the opponent's match history from a json file.
 
-    store_opponent_data(self, result: Union[Result, str]) -> None:
+    store_opponent_data(self, result: Result | str) -> None:
         Save the result of the current match to the opponent's match history.
     """
 
-    def __init__(self, ai, config: Dict, mediator: ManagerMediator) -> None:
+    def __init__(self, ai, config: dict, mediator: ManagerMediator) -> None:
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {
             ManagerRequestType.GET_CHOSEN_OPENING: lambda kwargs: self.chosen_opening
@@ -108,7 +107,7 @@ class DataManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Optional[Union[str, list[str]]]:
+    ) -> str | list[str] | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -125,7 +124,7 @@ class DataManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[BotMode, List[BotMode]]] :
+        BotMode | list[BotMode] | None :
             Either one of the ability dictionaries is being returned or a function that
             returns None was called from a different manager (please don't do that).
 
@@ -268,13 +267,13 @@ class DataManager(Manager, IManagerMediator):
         logger.info("All builds have invalid winrate, using cycle logic")
         self._choose_opening_cycle()
 
-    def _get_build_cycle(self) -> List[str]:
+    def _get_build_cycle(self) -> list[str]:
         if self.config[DEBUG]:
             opponent_id: str = TEST_OPPONENT_ID
         else:
             opponent_id: str = self.ai.opponent_id
 
-        build_cycle: List[str] = []
+        build_cycle: list[str] = []
         if BUILD_CHOICES in self.config:
             # get a build cycle from config depending on ai arena opponent id
             if opponent_id in self.config[BUILD_CHOICES]:
@@ -302,7 +301,7 @@ class DataManager(Manager, IManagerMediator):
                 }
             ]
 
-    def store_opponent_data(self, result: Union[Result, str]) -> None:
+    def store_opponent_data(self, result: Result | str) -> None:
         # only write results once
         if self.data_saved:
             return

--- a/src/ares/managers/data_manager.py
+++ b/src/ares/managers/data_manager.py
@@ -1,5 +1,7 @@
 """Handle data."""
 
+from __future__ import annotations
+
 import json
 import os
 from collections import defaultdict, deque

--- a/src/ares/managers/enemy_to_base_manager.py
+++ b/src/ares/managers/enemy_to_base_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from enum import Enum, auto
 

--- a/src/ares/managers/enemy_to_base_manager.py
+++ b/src/ares/managers/enemy_to_base_manager.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from enum import Enum, auto
-from typing import DefaultDict, Union
 
 from cython_extensions import cy_closest_to
 from sc2.unit import Unit
@@ -74,12 +73,12 @@ class EnemyToBaseManager(Manager, IManagerMediator):
         }
 
         # key:townhall tag, value: Enemy ground units near that base
-        self.ground_enemy_near_bases: DefaultDict[
+        self.ground_enemy_near_bases: defaultdict[
             int,
             set[int],
         ] = defaultdict(set)
         # key:townhall tag, value: Enemy flying units near that base
-        self.flying_enemy_near_bases: DefaultDict[
+        self.flying_enemy_near_bases: defaultdict[
             int,
             set[int],
         ] = defaultdict(set)
@@ -108,7 +107,7 @@ class EnemyToBaseManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Union[dict, int, Units]:
+    ) -> dict | int | Units:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -125,7 +124,7 @@ class EnemyToBaseManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Union[dict, int, Units] :
+        int | dict | Units :
             Types that can be returned from mediator requests via this manager.
 
         """

--- a/src/ares/managers/enemy_to_base_manager.py
+++ b/src/ares/managers/enemy_to_base_manager.py
@@ -46,11 +46,11 @@ class EnemyToBaseManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(EnemyToBaseManager, self).__init__(ai, config, mediator)
@@ -112,11 +112,11 @@ class EnemyToBaseManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        receiver :
+        receiver : ManagerName
             This Manager.
-        request :
+        request : ManagerRequestType
             What kind of request is being made
-        reason :
+        reason : str = None
             Why the reason is being made
         kwargs :
             Additional keyword args if needed for the specific request, as determined
@@ -126,7 +126,6 @@ class EnemyToBaseManager(Manager, IManagerMediator):
         -------
         int | dict | Units :
             Types that can be returned from mediator requests via this manager.
-
         """
         return self.manager_requests_dict[request](kwargs)
 

--- a/src/ares/managers/flying_structure_manager.py
+++ b/src/ares/managers/flying_structure_manager.py
@@ -1,6 +1,6 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
-from typing import TYPE_CHECKING, Dict, Optional
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared
@@ -26,7 +26,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -34,11 +34,11 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
 
         Returns
@@ -72,11 +72,11 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        receiver :
+        receiver : ManagerName
             This Manager.
-        request :
+        request : ManagerRequestType
             What kind of request is being made
-        reason :
+        reason : str = None
             Why the reason is being made
         kwargs :
             Additional keyword args if needed for the specific request, as determined

--- a/src/ares/managers/flying_structure_manager.py
+++ b/src/ares/managers/flying_structure_manager.py
@@ -1,6 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
 from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared
 from sc2.ids.ability_id import AbilityId
@@ -25,8 +26,8 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -66,7 +67,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -83,7 +84,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Dict] :
+        dict | None :
             Either one of the ability dictionaries is being returned or a function that
             returns None was called from a different manager (please don't do that).
 
@@ -134,7 +135,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
         for structure_tag, info in self._flying_structure_tracker.items():
             target: Point2 = info["destination"]
             should_land: bool = info["should_land"]
-            structure: Optional[Unit] = self.ai.unit_tag_dict.get(structure_tag, None)
+            structure: Unit | None = self.ai.unit_tag_dict.get(structure_tag, None)
             if not structure:
                 tags_to_remove.append(structure_tag)
                 continue

--- a/src/ares/managers/flying_structure_manager.py
+++ b/src/ares/managers/flying_structure_manager.py
@@ -1,6 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared
@@ -66,7 +67,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 

--- a/src/ares/managers/grid_manager.py
+++ b/src/ares/managers/grid_manager.py
@@ -110,8 +110,7 @@ class GridManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:

--- a/src/ares/managers/grid_manager.py
+++ b/src/ares/managers/grid_manager.py
@@ -6,7 +6,7 @@ cost calculations, and influence management.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from map_analyzer import MapData
@@ -112,6 +112,7 @@ class GridManager(Manager, IManagerMediator):
         self,
         ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -195,14 +196,14 @@ class GridManager(Manager, IManagerMediator):
             default_weight=200
         )
 
-        self.forcefield_positions: List[Point2] = []
+        self.forcefield_positions: list[Point2] = []
         # biles / nukes
-        self.delayed_effects: Dict[int, int] = {}
+        self.delayed_effects: dict[int, int] = {}
 
         # track biles, since they disappear from the observation right before they land
         # key is position, value is the frame the bile was first seen (50 frames total)
-        self.biles_dict: Dict[Point2, int] = {}
-        self.storms_dict: Dict[Point2, int] = {}
+        self.biles_dict: dict[Point2, int] = {}
+        self.storms_dict: dict[Point2, int] = {}
 
     async def update(self, iteration: int) -> None:
         """Keep track of everything.
@@ -330,9 +331,9 @@ class GridManager(Manager, IManagerMediator):
         pos: Point2,
         weight: float,
         unit_range: float,
-        grids: List[np.ndarray],
+        grids: list[np.ndarray],
         initial_default_weights: int = 0,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """Add values to multiple grids at once.
 
         Costs can also be considered "influence", mostly used to add enemies to a grid.
@@ -353,7 +354,7 @@ class GridManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[np.ndarray] :
+        list[np.ndarray] :
             The updated grids.
         """
         return self.map_data.add_cost_to_multiple_grids(
@@ -425,13 +426,13 @@ class GridManager(Manager, IManagerMediator):
 
     def _add_effects(self) -> None:
         """Add effects influence to map."""
-        effect_values: Dict = self.config[PATHING][EFFECTS]
+        effect_values: dict = self.config[PATHING][EFFECTS]
         effects_buffer = self.config[PATHING][EFFECTS_RANGE_BUFFER]
 
         self._process_game_effects(effect_values, effects_buffer)
         self._process_parasitic_bombs(effect_values, effects_buffer)
 
-    def _process_game_effects(self, effect_values: Dict, effects_buffer: float) -> None:
+    def _process_game_effects(self, effect_values: dict, effects_buffer: float) -> None:
         """Process all game effects and add their influence."""
         effect_handlers = {
             EffectId.BLINDINGCLOUDCP: self._handle_blinding_cloud,
@@ -455,14 +456,14 @@ class GridManager(Manager, IManagerMediator):
                 effect_handlers[effect.id](effect, effect_values, effects_buffer)
 
     def _process_parasitic_bombs(
-        self, effect_values: Dict, effects_buffer: float
+        self, effect_values: dict, effects_buffer: float
     ) -> None:
         """Process parasitic bomb effects."""
         for position in self.ai.enemy_parasitic_bomb_positions:
             self._handle_parasitic_bomb(position, effect_values, effects_buffer)
 
     def _handle_blinding_cloud(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle blinding cloud effect."""
         grids = [
@@ -478,7 +479,7 @@ class GridManager(Manager, IManagerMediator):
         )
 
     def _handle_kd8_charge(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle KD8 charge effect."""
         grids = [self.climber_grid, self.ground_grid]
@@ -490,7 +491,7 @@ class GridManager(Manager, IManagerMediator):
         )
 
     def _handle_liberator_siege(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle liberator siege effect."""
         grids = [self.climber_grid, self.ground_grid]
@@ -502,7 +503,7 @@ class GridManager(Manager, IManagerMediator):
         )
 
     def _handle_lurker_spines(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle lurker spines effect."""
         grids = [
@@ -518,14 +519,14 @@ class GridManager(Manager, IManagerMediator):
                 grids,
             )
 
-    def _handle_nuke(self, effect, effect_values: Dict, effects_buffer: float) -> None:
+    def _handle_nuke(self, effect, effect_values: dict, effects_buffer: float) -> None:
         """Handle nuke effect."""
         self._add_delayed_effect(
             position=Point2.center(effect.positions),
             effect_dict=self.storms_dict,
         )
 
-    def _handle_storm(self, effect, effect_values: Dict, effects_buffer: float) -> None:
+    def _handle_storm(self, effect, effect_values: dict, effects_buffer: float) -> None:
         """Handle psi storm effect."""
         grids = [
             self.air_grid,
@@ -544,7 +545,7 @@ class GridManager(Manager, IManagerMediator):
         )
 
     def _handle_corrosive_bile(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle corrosive bile effect."""
         self._add_delayed_effect(
@@ -553,7 +554,7 @@ class GridManager(Manager, IManagerMediator):
         )
 
     def _handle_forcefield(
-        self, effect, effect_values: Dict, effects_buffer: float
+        self, effect, effect_values: dict, effects_buffer: float
     ) -> None:
         """Handle forcefield effect."""
         self.forcefield_positions.append(effect.positions.pop())
@@ -561,7 +562,7 @@ class GridManager(Manager, IManagerMediator):
     def _handle_parasitic_bomb(
         self,
         position: Point2,
-        effect_values: Dict,
+        effect_values: dict,
         effects_buffer: float,
     ) -> None:
         """Handle parasitic bomb effect."""
@@ -959,7 +960,7 @@ class GridManager(Manager, IManagerMediator):
             How long the effect lasts.
         """
         current_frame: int = self.ai.state.game_loop
-        keys_to_remove: List[Point2] = []
+        keys_to_remove: list[Point2] = []
 
         for position, frame_commenced in effect_dict.items():
             if current_frame - frame_commenced > effect_duration:
@@ -972,7 +973,7 @@ class GridManager(Manager, IManagerMediator):
         self,
         cost: float,
         radius: float,
-        effect_dict: Dict,
+        effect_dict: dict,
         react_on_frame: int,
     ) -> None:
         """Add the costs of the delayed effects to the grids.

--- a/src/ares/managers/hub.py
+++ b/src/ares/managers/hub.py
@@ -1,6 +1,7 @@
 """The core of the bot."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.data import Race, Result

--- a/src/ares/managers/hub.py
+++ b/src/ares/managers/hub.py
@@ -1,6 +1,7 @@
 """The core of the bot."""
 
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from sc2.data import Race, Result
 from sc2.unit import Unit
@@ -41,8 +42,8 @@ class Hub:
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         manager_mediator: ManagerMediator,
         data_manager: DataManager = None,
         enemy_to_base_manager: EnemyToBaseManager = None,
@@ -56,7 +57,7 @@ class Hub:
         terrain_manager: TerrainManager = None,
         resource_manager: ResourceManager = None,
         building_manager: BuildingManager = None,
-        additional_managers: Optional[List["Manager"]] = None,
+        additional_managers: list["Manager"] | None = None,
     ) -> None:
         """Initialise Manager objects and set update priority.
 
@@ -96,7 +97,7 @@ class Hub:
         """
         self.ai: "AresBot" = ai
         self.debug: bool = config[DEBUG]
-        self.config: Dict = config
+        self.config: dict = config
         self.manager_mediator: ManagerMediator = manager_mediator
         self._is_zerg: bool = ai.race == Race.Zerg
 
@@ -251,7 +252,7 @@ class Hub:
         # self.building_manager.remove_unit(unit_tag)
         self.nydus_manager.remove_destroyed_nydus(unit_tag)
 
-    def on_game_end(self, result: Union[Result, str]) -> None:
+    def on_game_end(self, result: str | Result) -> None:
         """Store data from the completed game.
 
         Parameters

--- a/src/ares/managers/hub.py
+++ b/src/ares/managers/hub.py
@@ -1,6 +1,6 @@
 """The core of the bot."""
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sc2.data import Race, Result
@@ -42,7 +42,7 @@ class Hub:
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         manager_mediator: ManagerMediator,
         data_manager: DataManager = None,
@@ -95,7 +95,7 @@ class Hub:
             Additional custom managers
 
         """
-        self.ai: "AresBot" = ai
+        self.ai: AresBot = ai
         self.debug: bool = config[DEBUG]
         self.config: dict = config
         self.manager_mediator: ManagerMediator = manager_mediator

--- a/src/ares/managers/intel_manager.py
+++ b/src/ares/managers/intel_manager.py
@@ -130,7 +130,7 @@ class IntelManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Any :
+        Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
             Everything that could possibly be returned from the Manager fits in there
         """
         if self.ai.arcade_mode:

--- a/src/ares/managers/intel_manager.py
+++ b/src/ares/managers/intel_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from cython_extensions import cy_distance_to_squared

--- a/src/ares/managers/intel_manager.py
+++ b/src/ares/managers/intel_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from cython_extensions import cy_distance_to_squared
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 class IntelManager(Manager, IManagerMediator):
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -128,9 +129,8 @@ class IntelManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
+        Any :
             Everything that could possibly be returned from the Manager fits in there
-
         """
         if self.ai.arcade_mode:
             logger.warning(

--- a/src/ares/managers/manager.py
+++ b/src/ares/managers/manager.py
@@ -1,7 +1,7 @@
 """Base class for Managers."""
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from sc2.units import Units
 
@@ -28,7 +28,7 @@ class Manager(metaclass=ABCMeta):
 
     """
 
-    def __init__(self, ai: "AresBot", config: Dict, mediator: ManagerMediator) -> None:
+    def __init__(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> None:
         """Set up the manager.
 
         Parameters
@@ -46,7 +46,7 @@ class Manager(metaclass=ABCMeta):
         """
         super().__init__()
         self.ai: AresBot = ai
-        self.config: Dict = config
+        self.config: dict = config
         self.manager_mediator: ManagerMediator = mediator
         self.empty_units: Units = Units([], self.ai)
 

--- a/src/ares/managers/manager.py
+++ b/src/ares/managers/manager.py
@@ -66,7 +66,7 @@ class Manager(metaclass=ABCMeta):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> Any:
         """To be implemented by managers that inherit from IManagerMediator interface.
 

--- a/src/ares/managers/manager.py
+++ b/src/ares/managers/manager.py
@@ -1,5 +1,7 @@
 """Base class for Managers."""
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
     DefaultDict,
     Dict,
     Optional,
@@ -14,6 +10,7 @@ from typing import (
     Tuple,
     Union,
 )
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 from map_analyzer import MapData
@@ -38,7 +35,7 @@ class IManagerMediator(metaclass=ABCMeta):
     """
 
     # each manager has a dict linking the request type to a callable action
-    manager_requests_dict: Dict[ManagerRequestType, Callable]
+    manager_requests_dict: dict[ManagerRequestType, Callable]
 
     @abstractmethod
     def manager_request(
@@ -73,13 +70,13 @@ class ManagerMediator(IManagerMediator):
     """
 
     def __init__(self) -> None:
-        self.managers: Dict[str, "Manager"] = {}  # noqa
+        self.managers: dict[str, "Manager"] = {}  # noqa
 
     def add_managers(self, managers: list["Manager"]) -> None:  # noqa
         """Generate manager dictionary.
 
         Parameters:
-            managers: List of all Managers capable of handling ManagerRequests.
+            managers: `list` of all Managers capable of handling ManagerRequests.
         """
         for manager in managers:
             self.managers[str(type(manager).__name__)] = manager
@@ -203,13 +200,13 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_building_counter(self) -> DefaultDict[UnitTypeId, int]:
+    def get_building_counter(self) -> defaultdict[UnitTypeId, int]:
         """Get a dictionary containing the number of each type of building in progress.
 
         BuildingManager.
 
         Returns:
-            DefaultDict[UnitTypeId, int]:
+            defaultdict[UnitTypeId, int]:
                 Number of each type of UnitTypeId
                 currently being tracked for building.
         """
@@ -220,13 +217,13 @@ class ManagerMediator(IManagerMediator):
     @property
     def get_building_tracker_dict(
         self,
-    ) -> dict[int, dict[str, Union[Point2, Unit, UnitTypeId, float]]]:
+    ) -> dict[int, dict[str, float | Point2 | Unit | UnitTypeId]]:
         """Get the building tracker dictionary.
 
         Building Manager.
 
         Returns:
-            dict[int, dict[str, Union[Point2, Unit, UnitTypeId, float]]]:
+            dict[int, dict[str, float | Point2 | Unit | UnitTypeId]]:
                 Tracks the worker tag to details such as the UnitTypeId of the
                 building, the Point2 location for placement, the in-game
                 time when the order started, and the purpose of the building.
@@ -1014,7 +1011,7 @@ class ManagerMediator(IManagerMediator):
     @property
     def get_nydus_travellers_dict(
         self, **kwargs
-    ) -> dict[int, dict[str, Union[int, Point2, UnitTypeId]]]:
+    ) -> dict[int, dict[str, int | Point2 | UnitTypeId]]:
         """Get the nydus travellers dictionary.
 
         NydusManager
@@ -1090,7 +1087,7 @@ class ManagerMediator(IManagerMediator):
     """
 
     @property
-    def get_mineral_patch_to_list_of_workers(self) -> Dict[int, Set[int]]:
+    def get_mineral_patch_to_list_of_workers(self) -> dict[int, set[int]]:
         """Get a dictionary containing mineral tag to worker tags
 
         Resource Manager
@@ -1215,7 +1212,7 @@ class ManagerMediator(IManagerMediator):
             grid (np.ndarray): The grid that should be used for pathing.
 
         Returns:
-            List of points composing the path.
+            `list` of points composing the path.
         """
         return self.manager_request(
             ManagerName.PATH_MANAGER,
@@ -1324,7 +1321,7 @@ class ManagerMediator(IManagerMediator):
                 the full path between tiles that are returned.
 
         Returns:
-            List of points composing the path.
+            `list` of points composing the path.
         """
         return self.manager_request(
             ManagerName.PATH_MANAGER, ManagerRequestType.FIND_RAW_PATH, **kwargs
@@ -1472,7 +1469,7 @@ class ManagerMediator(IManagerMediator):
         ```
 
         Returns:
-            List of the center point of forcefields.
+            `list` of the center point of forcefields.
 
         """
         return self.manager_request(
@@ -1738,7 +1735,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_pvz_nat_gatekeeping_pos(self, **kwargs) -> Union[Point2, None]:
+    def get_pvz_nat_gatekeeping_pos(self, **kwargs) -> Point2 | None:
         """Get the gatekeeper position in a PvZ natural wall if available.
 
         WARNING: This can return `None` so your code should account for this.
@@ -1775,7 +1772,7 @@ class ManagerMediator(IManagerMediator):
             **kwargs,
         )
 
-    def request_building_placement(self, **kwargs) -> Optional[Point2]:
+    def request_building_placement(self, **kwargs) -> Point2 | None:
         """Request a building placement from the precalculated building formation.
 
         PlacementManager
@@ -1824,7 +1821,7 @@ class ManagerMediator(IManagerMediator):
 
         Parameters:
             unit_type (UnitTypeId): The unit we want to warp in.
-            target (Optional[Point2]): If provided, attempt to find
+            target (Point2 | None): If provided, attempt to find
                 spot closest to this location.
         """
         return self.manager_request(
@@ -1871,7 +1868,7 @@ class ManagerMediator(IManagerMediator):
             **kwargs,
         )
 
-    def select_worker(self, **kwargs) -> Optional[Unit]:
+    def select_worker(self, **kwargs) -> Unit | None :
         """Select a worker via the ResourceManager.
 
         This way we can select one assigned to a far mineral patch.
@@ -1984,7 +1981,7 @@ class ManagerMediator(IManagerMediator):
     TerrainManager
     """
 
-    def building_position_blocked_by_burrowed_unit(self, **kwargs) -> Optional[Point2]:
+    def building_position_blocked_by_burrowed_unit(self, **kwargs) -> Point2 | None:
         """See if the building position is blocked by a burrowed unit.
 
         TerrainManager
@@ -2054,13 +2051,13 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_enemy_expansions(self) -> list[Tuple[Point2, float]]:
+    def get_enemy_expansions(self) -> list[tuple[Point2, float]]:
         """Get the expansions, as ordered from the enemy's point of view.
 
         TerrainManager
 
         Returns:
-            list[Tuple[Point2, float]]:
+            list[tuple[Point2, float]]:
                 The first element is the
                 location of the base. The second element is the pathing
                 distance from the enemy main base.
@@ -2136,7 +2133,7 @@ class ManagerMediator(IManagerMediator):
                 distance to the start point.
 
         Returns:
-            Tuple[int, List[Tuple[int, int]]]:
+            tuple[int, list[tuple[int, int]]]:
                 First element is the number of valid points.
                 Second element is the list of all valid points.
         """
@@ -2207,7 +2204,7 @@ class ManagerMediator(IManagerMediator):
         TerrainManager
 
         Returns:
-            List of Overlord hiding spots.
+            `list` of Overlord hiding spots.
 
         """
         return self.manager_request(
@@ -2216,13 +2213,13 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_own_expansions(self) -> list[Tuple[Point2, float]]:
+    def get_own_expansions(self) -> list[tuple[Point2, float]]:
         """Get the expansions.
 
         TerrainManager
 
         Returns:
-            List[Tuple[Point2, float]]: List of Tuples where
+            list[tuple[Point2, float]]: `list` of `tuple`s where
                 The first element is the location of the base.
                 The second element is the pathing distance from our main base.
         """
@@ -2250,7 +2247,7 @@ class ManagerMediator(IManagerMediator):
         TerrainManager
 
         Returns:
-            List of build positions that are blocked by a burrowed enemy unit.
+            `list` of build positions that are blocked by a burrowed enemy unit.
 
         """
         return self.manager_request(
@@ -2289,7 +2286,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_enemy_army_dict(self) -> DefaultDict[UnitTypeId, list[Unit]]:
+    def get_enemy_army_dict(self) -> defaultdict[UnitTypeId, list[Unit]]:
         """Get the dictionary of enemy army unit types to the units themselves.
 
         UnitCacheManager
@@ -2304,7 +2301,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_old_own_army_dict(self) -> Dict[UnitTypeId, list[Unit]]:
+    def get_old_own_army_dict(self) -> dict[UnitTypeId, list[Unit]]:
         """Get the previous iteration's `own_army` dict.
 
         UnitCacheManager
@@ -2330,7 +2327,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_own_army_dict(self) -> Dict[UnitTypeId, list[Unit]]:
+    def get_own_army_dict(self) -> dict[UnitTypeId, list[Unit]]:
         """Get the dictionary of own army unit types to the units themselves.
 
         UnitCacheManager
@@ -2343,7 +2340,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_own_structures_dict(self) -> DefaultDict[UnitTypeId, list[Unit]]:
+    def get_own_structures_dict(self) -> defaultdict[UnitTypeId, list[Unit]]:
         """Get the dictionary of own structure types to the units themselves.
 
         UnitCacheManager
@@ -2477,7 +2474,7 @@ class ManagerMediator(IManagerMediator):
 
     def get_units_in_range(
         self, **kwargs
-    ) -> Union[Dict[Union[int, Tuple[float, float]], Units], list[Units]]:
+    ) -> dict[int | tuple[float, float], Units] | list[Units]:
         """Get units in range of other units or points.
 
         UnitMemoryManager
@@ -2554,14 +2551,14 @@ class ManagerMediator(IManagerMediator):
         )
 
     def batch_assign_role(self, **kwargs) -> None:
-        """Assign a given role to a List of unit tags.
+        """Assign a given role to a list of unit tags.
 
         Nothing more than a for loop, provided for convenience.
 
         UnitRoleManager
 
         Parameters:
-            tags (Set[int]): Tags of the units to assign to a role.
+            tags (set[int]): Tags of the units to assign to a role.
             role (UnitRole): The role the units should be assigned to.
         """
         return self.manager_request(
@@ -2588,8 +2585,8 @@ class ManagerMediator(IManagerMediator):
         UnitRoleManager
 
         Parameters:
-            roles (Set[UnitRole]): Roles to get units from.
-            excluded (Set[UnitTypeId]): Unit types that should not be included.
+            roles (set[UnitRole]): Roles to get units from.
+            excluded (set[UnitTypeId]): Unit types that should not be included.
 
         Returns:
             Units matching the role that are not of an excluded type.
@@ -2601,7 +2598,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     @property
-    def get_unit_role_dict(self) -> Dict[UnitRole, Set[int]]:
+    def get_unit_role_dict(self) -> dict[UnitRole, set[int]]:
         """Get the dictionary of `UnitRole` to the set of tags of units with that role.
 
         UnitRoleManager
@@ -2626,7 +2623,7 @@ class ManagerMediator(IManagerMediator):
             role (UnitRole): Role to get units from.
             unit_type (UnitTypeId): Type(s) of units that should be returned.
                 If omitted, all units with the role will be returned.
-            restrict_to (Set[UnitTypeId]): If supplied, only take Units
+            restrict_to (set[UnitTypeId]): If supplied, only take Units
                 with the given role and type if they also exist here.
 
         Returns:
@@ -2644,7 +2641,7 @@ class ManagerMediator(IManagerMediator):
         UnitRoleManager
 
         Parameters:
-            roles (Set[UnitRole]): Roles to get units from.
+            roles (set[UnitRole]): Roles to get units from.
             unit_type (UnitTypeId): Type(s) of units that should be returned.
                 If omitted, all units with the role will be returned.
 

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -3,13 +3,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-    DefaultDict,
-    Dict,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -297,7 +297,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     def get_closest_creep_tile(self, **kwargs) -> None | Point2:
-        """Get closest creep tile to `pos`
+        """Get the closest creep tile to pos
 
         WARNING: May return `None` if no creep tiles observed.
 
@@ -1236,30 +1236,41 @@ class ManagerMediator(IManagerMediator):
     def find_path_next_point(self, **kwargs) -> Point2:
         """Find the next point in a path.
 
-        Parameters:
-            start (Point2): Start point of the path.
-            target (Point2): Desired end point of the path.
-            grid (np.ndarray): The grid that should be used for pathing.
-            sensitivity (int, optional): Amount of points that should be
-                skipped in the full path between tiles that are returned.
-                Default value is 5.
-            smoothing (bool, optional): Optional path smoothing where nodes are
-                removed if it's possible to jump ahead some tiles in
-                a straight line with a lower cost.
-                Default value is False.
-            sense_danger (bool, optional): Check to see if there are any
-                dangerous tiles near the starting point. If this is True and
-                there are no dangerous tiles near the starting point,
-                the pathing query is skipped and the target is returned.
-                Default value is True.
-            danger_distance (float, optional): How far away from the
-                start to look for danger.
-                Default value is 20.
-            danger_threshold (float, optional): Minimum value for a tile
-                to be considered dangerous.
-                Default value is 5.
+        Parameters
+        ----------
+        start : Point2
+            Start point of the path.
+        target : Point2
+            Desired end point of the path.
+        grid : np.ndarray
+            The grid that should be used for pathing.
+        sensitivity : int | None
+            Amount of points that should be
+            skipped in the full path between tiles that are returned.
+            Default value is 5.
+        smoothing : bool | None
+            Optional path smoothing where nodes are
+            removed if it's possible to jump ahead some tiles in
+            a straight line with a lower cost.
+            Default value is False.
+        sense_danger : bool | None
+            Check to see if there are any
+            dangerous tiles near the starting point. If this is True and
+            there are no dangerous tiles near the starting point,
+            the pathing query is skipped and the target is returned.
+            Default value is True.
+        danger_distance : float | None
+            How far away from the
+            start to look for danger.
+            Default value is 20.
+        danger_threshold : float | None
+            Minimum value for a tile
+            to be considered dangerous.
+            Default value is 5.
 
-        Returns:
+        Returns
+        -------
+        Point2
             The next point in the path from the start to the target which may be the
             same as the target if it's safe.
         """
@@ -1272,31 +1283,37 @@ class ManagerMediator(IManagerMediator):
     ) -> tuple[Point2 | None, Point2 | None, list[int] | None]:
         """Find the next point in a path including via nyduses.
 
-        Parameters:
-            start (Point2): Start point of the path.
-            target (Point2): Desired end point of the path.
-            grid (np.ndarray): The grid that should be used for pathing.
-            sensitivity (int, optional): Amount of points that should be
-                skipped in the full path between tiles that are returned.
-                Default value is 5.
-            smoothing (bool, optional): Optional path smoothing where nodes are
-                removed if it's possible to jump ahead some tiles in
-                a straight line with a lower cost.
-                Default value is False.
-            sense_danger (bool, optional): Check to see if there are any
-                dangerous tiles near the starting point. If this is True and
-                there are no dangerous tiles near the starting point,
-                the pathing query is skipped and the target is returned.
-                Default value is True.
-            danger_distance (float, optional): How far away from the
-                start to look for danger.
-                Default value is 20.
-            danger_threshold (float, optional): Minimum value for a tile
-                to be considered dangerous.
-                Default value is 5.
+        Parameters
+        ----------
+        start : Point2
+            Start point of the path.
+        target : Point2
+            Desired end point of the path.
+        grid : np.ndarray
+            The grid that should be used for pathing.
+        sensitivity : int = 5
+            Amount of points that should be
+            skipped in the full path between tiles that are returned.
+        smoothing : bool = False
+            Optional path smoothing where nodes are
+            removed if it's possible to jump ahead some tiles in
+            a straight line with a lower cost.
+        sense_danger : bool = True
+            Check to see if there are any
+            dangerous tiles near the starting point. If this is True and
+            there are no dangerous tiles near the starting point,
+            the pathing query is skipped and the target is returned.
+        danger_distance : float = 20
+            How far away from the
+            start to look for danger.
+        danger_threshold : float = 15
+            Minimum value for a tile
+            to be considered dangerous.
 
-        Returns:
-            Tuple of (next_point, nydus_next_point, nydus_points)
+        Returns
+        -------
+        tuple :
+            tuple of (next_point, nydus_next_point, nydus_points).
         """
         return self.manager_request(
             ManagerName.PATH_MANAGER, ManagerRequestType.NYDUS_PATH_NEXT_POINT, **kwargs
@@ -1771,35 +1788,47 @@ class ManagerMediator(IManagerMediator):
 
         PlacementManager
 
-        Parameters:
-            base_location (Point2): The general area where the placement should be near.
-                This should be an expansion location.
-            structure_type (UnitTypeId): Structure type requested.
-            first_pylon (bool, optional): Try to take designated
-                first pylon if available.
-                Default value is False.
-            static_defence (bool, optional): Try to take designated
-                static defence placements if available.
-                Default value is False.
-            wall (bool, optional): Request a wall structure placement.
-                Will find alternative if no wall placements available.
-                Default value is False.
-            find_alternative (bool, optional): If no placements available
-                at base_location, find an alternative at a nearby base.
-                Default value is True.
-            reserve_placement (bool, optional): Reserve this booking for a
-                while, so another customer doesn't request it.
-                Default value is True.
-            within_psionic_matrix (bool, optional): Protoss specific -> calculated
-                position have power?
-                Default value is False.
-            pylon_build_progress (float, optional): Only relevant
-                if `within_psionic_matrix = True`.
-                Default value is 1.0.
-            closest_to (Point2, optional): Find placement at base closest to this.
+        Parameters
+        ----------
+        base_location : Point2
+            The general area where the placement should be near.
+            This should be an expansion location.
+        structure_type : UnitTypeId
+            Structure type requested.
+        first_pylon : bool, optional
+            Try to take designated
+            first pylon if available.
+            Default value is False.
+        static_defence : bool, optional
+            Try to take designated
+            static defence placements if available.
+            Default value is False.
+        wall : bool, optional
+            Request a wall structure placement.
+            Will find alternative if no wall placements available.
+            Default value is False.
+        find_alternative : bool, optional
+            If no placements available
+            at base_location, find an alternative at a nearby base.
+            Default value is True.
+        reserve_placement : bool, optional
+            Reserve this booking for a
+            while, so another customer doesn't request it.
+            Default value is True.
+        within_psionic_matrix : bool, optional
+            Protoss specific -> calculated
+            position have power?
+            Default value is False.
+        pylon_build_progress : float, optional
+            Only relevant
+            if `within_psionic_matrix = True`.
+            Default value is 1.0.
+        closest_to : Point2, optional
+            Find placement at base closest to this.
 
-
-        Returns:
+        Returns
+        -------
+        Point2 | None
             Indicating if structure can be placed at given position.
         """
         return self.manager_request(
@@ -1980,11 +2009,16 @@ class ManagerMediator(IManagerMediator):
 
         TerrainManager
 
-        Parameters:
-            worker_tag (int): The worker attempting to build the structure.
-            position (Point2): Where the structure is attempting to be placed.
+        Parameters
+        ----------
+        worker_tag : int
+            The worker attempting to build the structure.
+        position : Point2
+            Where the structure is attempting to be placed.
 
-        Returns:
+        Returns
+        -------
+        Point2 | None
             The position that's blocked by an enemy unit.
         """
         return self.manager_request(
@@ -2473,22 +2507,24 @@ class ManagerMediator(IManagerMediator):
 
         UnitMemoryManager
 
-        Parameters:
-            start_points (List[Union[Unit, Tuple[float, float]]]):
-                List of `Unit`s or positions to search for units from.
-            distances (Union[float, List[float]]): How far away from each point to
-                query. Must broadcast to the length of `start_points`.
-            query_tree (UnitTreeQueryType): Which KDTree should be queried.
-            return_as_dict (bool, optional): Sets whether the returned units in range
-                should be a dictionary or list. Default is False.
+        Parameters
+        ----------
+        start_points : list[Unit | tuple[float, float]]
+            `list` of `Unit`s or positions to search for units from.
+        distances : float | list[float]
+            How far away from each point to query. Must broadcast to the length
+            of `start_points`.
+        query_tree : UnitTreeQueryType
+            Which KDTree should be queried.
+        return_as_dict : bool = False
+            Sets whether the returned units in range should be a dictionary or list.
 
-
-        Returns:
-            Union[Dict[Union[int, Tuple[float, float]], Units], List[Units]]:
-                Returns the units in range of each start point as a `dict` where the key
-                is the unit tag or position and the value is the `Units` in range or a
-                `list` of `Units`.
-
+        Returns
+        -------
+        dict[int | tuple[float, float], Units] | list[Units]
+            Returns the units in range of each start point as a `dict` where the key
+            is the unit tag or position and the value is the `Units` in range or a
+            `list` of `Units`.
         """
         return self.manager_request(
             ManagerName.UNIT_MEMORY_MANAGER,

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -1236,41 +1236,30 @@ class ManagerMediator(IManagerMediator):
     def find_path_next_point(self, **kwargs) -> Point2:
         """Find the next point in a path.
 
-        Parameters
-        ----------
-        start : Point2
-            Start point of the path.
-        target : Point2
-            Desired end point of the path.
-        grid : np.ndarray
-            The grid that should be used for pathing.
-        sensitivity : int | None
-            Amount of points that should be
-            skipped in the full path between tiles that are returned.
-            Default value is 5.
-        smoothing : bool | None
-            Optional path smoothing where nodes are
-            removed if it's possible to jump ahead some tiles in
-            a straight line with a lower cost.
-            Default value is False.
-        sense_danger : bool | None
-            Check to see if there are any
-            dangerous tiles near the starting point. If this is True and
-            there are no dangerous tiles near the starting point,
-            the pathing query is skipped and the target is returned.
-            Default value is True.
-        danger_distance : float | None
-            How far away from the
-            start to look for danger.
-            Default value is 20.
-        danger_threshold : float | None
-            Minimum value for a tile
-            to be considered dangerous.
-            Default value is 5.
+        Parameters:
+            start (Point2): Start point of the path.
+            target (Point2): Desired end point of the path.
+            grid (np.ndarray): The grid that should be used for pathing.
+            sensitivity (int, optional): Amount of points that should be
+                skipped in the full path between tiles that are returned.
+                Default value is 5.
+            smoothing (bool, optional): Optional path smoothing where nodes are
+                removed if it's possible to jump ahead some tiles in
+                a straight line with a lower cost.
+                Default value is False.
+            sense_danger (bool, optional): Check to see if there are any
+                dangerous tiles near the starting point. If this is True and
+                there are no dangerous tiles near the starting point,
+                the pathing query is skipped and the target is returned.
+                Default value is True.
+            danger_distance (float, optional): How far away from the
+                start to look for danger.
+                Default value is 20.
+            danger_threshold (float, optional): Minimum value for a tile
+                to be considered dangerous.
+                Default value is 5.
 
-        Returns
-        -------
-        Point2
+        Returns:
             The next point in the path from the start to the target which may be the
             same as the target if it's safe.
         """
@@ -1283,37 +1272,31 @@ class ManagerMediator(IManagerMediator):
     ) -> tuple[Point2 | None, Point2 | None, list[int] | None]:
         """Find the next point in a path including via nyduses.
 
-        Parameters
-        ----------
-        start : Point2
-            Start point of the path.
-        target : Point2
-            Desired end point of the path.
-        grid : np.ndarray
-            The grid that should be used for pathing.
-        sensitivity : int = 5
-            Amount of points that should be
-            skipped in the full path between tiles that are returned.
-        smoothing : bool = False
-            Optional path smoothing where nodes are
-            removed if it's possible to jump ahead some tiles in
-            a straight line with a lower cost.
-        sense_danger : bool = True
-            Check to see if there are any
-            dangerous tiles near the starting point. If this is True and
-            there are no dangerous tiles near the starting point,
-            the pathing query is skipped and the target is returned.
-        danger_distance : float = 20
-            How far away from the
-            start to look for danger.
-        danger_threshold : float = 15
-            Minimum value for a tile
-            to be considered dangerous.
+        Parameters:
+            start (Point2): Start point of the path.
+            target (Point2): Desired end point of the path.
+            grid (np.ndarray): The grid that should be used for pathing.
+            sensitivity (int, optional): Amount of points that should be
+                skipped in the full path between tiles that are returned.
+                Default value is 5.
+            smoothing (bool, optional): Optional path smoothing where nodes are
+                removed if it's possible to jump ahead some tiles in
+                a straight line with a lower cost.
+                Default value is False.
+            sense_danger (bool, optional): Check to see if there are any
+                dangerous tiles near the starting point. If this is True and
+                there are no dangerous tiles near the starting point,
+                the pathing query is skipped and the target is returned.
+                Default value is True.
+            danger_distance (float, optional): How far away from the
+                start to look for danger.
+                Default value is 20.
+            danger_threshold (float, optional): Minimum value for a tile
+                to be considered dangerous.
+                Default value is 5.
 
-        Returns
-        -------
-        tuple :
-            tuple of (next_point, nydus_next_point, nydus_points).
+        Returns:
+            Tuple of (next_point, nydus_next_point, nydus_points)
         """
         return self.manager_request(
             ManagerName.PATH_MANAGER, ManagerRequestType.NYDUS_PATH_NEXT_POINT, **kwargs
@@ -1788,47 +1771,35 @@ class ManagerMediator(IManagerMediator):
 
         PlacementManager
 
-        Parameters
-        ----------
-        base_location : Point2
-            The general area where the placement should be near.
-            This should be an expansion location.
-        structure_type : UnitTypeId
-            Structure type requested.
-        first_pylon : bool, optional
-            Try to take designated
-            first pylon if available.
-            Default value is False.
-        static_defence : bool, optional
-            Try to take designated
-            static defence placements if available.
-            Default value is False.
-        wall : bool, optional
-            Request a wall structure placement.
-            Will find alternative if no wall placements available.
-            Default value is False.
-        find_alternative : bool, optional
-            If no placements available
-            at base_location, find an alternative at a nearby base.
-            Default value is True.
-        reserve_placement : bool, optional
-            Reserve this booking for a
-            while, so another customer doesn't request it.
-            Default value is True.
-        within_psionic_matrix : bool, optional
-            Protoss specific -> calculated
-            position have power?
-            Default value is False.
-        pylon_build_progress : float, optional
-            Only relevant
-            if `within_psionic_matrix = True`.
-            Default value is 1.0.
-        closest_to : Point2, optional
-            Find placement at base closest to this.
+        Parameters:
+            base_location (Point2): The general area where the placement should be near.
+                This should be an expansion location.
+            structure_type (UnitTypeId): Structure type requested.
+            first_pylon (bool, optional): Try to take designated
+                first pylon if available.
+                Default value is False.
+            static_defence (bool, optional): Try to take designated
+                static defence placements if available.
+                Default value is False.
+            wall (bool, optional): Request a wall structure placement.
+                Will find alternative if no wall placements available.
+                Default value is False.
+            find_alternative (bool, optional): If no placements available
+                at base_location, find an alternative at a nearby base.
+                Default value is True.
+            reserve_placement (bool, optional): Reserve this booking for a
+                while, so another customer doesn't request it.
+                Default value is True.
+            within_psionic_matrix (bool, optional): Protoss specific -> calculated
+                position have power?
+                Default value is False.
+            pylon_build_progress (float, optional): Only relevant
+                if `within_psionic_matrix = True`.
+                Default value is 1.0.
+            closest_to (Point2, optional): Find placement at base closest to this.
 
-        Returns
-        -------
-        Point2 | None
+
+        Returns:
             Indicating if structure can be placed at given position.
         """
         return self.manager_request(
@@ -1891,7 +1862,7 @@ class ManagerMediator(IManagerMediator):
             **kwargs,
         )
 
-    def select_worker(self, **kwargs) -> Unit | None :
+    def select_worker(self, **kwargs) -> Unit | None:
         """Select a worker via the ResourceManager.
 
         This way we can select one assigned to a far mineral patch.
@@ -2009,16 +1980,11 @@ class ManagerMediator(IManagerMediator):
 
         TerrainManager
 
-        Parameters
-        ----------
-        worker_tag : int
-            The worker attempting to build the structure.
-        position : Point2
-            Where the structure is attempting to be placed.
+        Parameters:
+            worker_tag (int): The worker attempting to build the structure.
+            position (Point2): Where the structure is attempting to be placed.
 
-        Returns
-        -------
-        Point2 | None
+        Returns:
             The position that's blocked by an enemy unit.
         """
         return self.manager_request(
@@ -2507,24 +2473,22 @@ class ManagerMediator(IManagerMediator):
 
         UnitMemoryManager
 
-        Parameters
-        ----------
-        start_points : list[Unit | tuple[float, float]]
-            `list` of `Unit`s or positions to search for units from.
-        distances : float | list[float]
-            How far away from each point to query. Must broadcast to the length
-            of `start_points`.
-        query_tree : UnitTreeQueryType
-            Which KDTree should be queried.
-        return_as_dict : bool = False
-            Sets whether the returned units in range should be a dictionary or list.
+        Parameters:
+            start_points (List[Union[Unit, Tuple[float, float]]]):
+                List of `Unit`s or positions to search for units from.
+            distances (Union[float, List[float]]): How far away from each point to
+                query. Must broadcast to the length of `start_points`.
+            query_tree (UnitTreeQueryType): Which KDTree should be queried.
+            return_as_dict (bool, optional): Sets whether the returned units in range
+                should be a dictionary or list. Default is False.
 
-        Returns
-        -------
-        dict[int | tuple[float, float], Units] | list[Units]
-            Returns the units in range of each start point as a `dict` where the key
-            is the unit tag or position and the value is the `Units` in range or a
-            `list` of `Units`.
+
+        Returns:
+            Union[Dict[Union[int, Tuple[float, float]], Units], List[Units]]:
+                Returns the units in range of each start point as a `dict` where the key
+                is the unit tag or position and the value is the `Units` in range or a
+                `list` of `Units`.
+
         """
         return self.manager_request(
             ManagerName.UNIT_MEMORY_MANAGER,

--- a/src/ares/managers/nydus_manager.py
+++ b/src/ares/managers/nydus_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any
 
@@ -33,7 +34,7 @@ class NydusManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -41,11 +42,11 @@ class NydusManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super().__init__(ai, config, mediator)
@@ -308,10 +309,10 @@ class NydusManager(Manager, IManagerMediator):
             return None
 
         # see if any enemies are in range 12 of each point
-        enemy_in_range_of_points: list[bool] = (
-            self.manager_mediator.get_any_enemies_in_range(
-                positions=potential_locations, radius=12.0
-            )
+        enemy_in_range_of_points: list[
+            bool
+        ] = self.manager_mediator.get_any_enemies_in_range(
+            positions=potential_locations, radius=12.0
         )
         # points that are far enough away
         distanced_locations: list[Point2] = [

--- a/src/ares/managers/nydus_manager.py
+++ b/src/ares/managers/nydus_manager.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, deque
-from typing import TYPE_CHECKING, Any, DefaultDict, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from cython_extensions.geometry import cy_distance_to_squared, cy_towards
@@ -62,9 +62,7 @@ class NydusManager(Manager, IManagerMediator):
 
         # key is tag of travelling unit,
         # value is dictionary of tags of ENTRY/EXIT nodes and UnitTypeId
-        self._nydus_travellers: dict[int, dict[str, Union[int, Point2, UnitTypeId]]] = (
-            {}
-        )
+        self._nydus_travellers: dict[int, dict[str, int | Point2 | UnitTypeId]] = {}
         self._nydus_tags_with_actions: set[int] = set()
         # if unit just left nydus, it will be banned from nydus travel for a bit
         self._units_banned_from_travelling: dict[int, float] = {}
@@ -264,7 +262,7 @@ class NydusManager(Manager, IManagerMediator):
         min_base_distance: float = 15.0,
         max_nydus_distance: float = 25.0,
         max_cost: int = 20,
-    ) -> Union[None, Point2]:
+    ) -> Point2 | None:
         """
         Find a Nydus position with pathing cost less than max_cost in
         a region containing the given point, at least
@@ -386,7 +384,7 @@ class NydusManager(Manager, IManagerMediator):
 
         # arrange the order units get out
         passengers: set[int] = nyduses[0].passengers_tags
-        exit_queue: DefaultDict[int, deque[int]] = defaultdict(deque)
+        exit_queue: defaultdict[int, deque[int]] = defaultdict(deque)
         for traveller_tag in passengers:
             if traveller_tag in self._nydus_travellers:
                 if self._nydus_travellers[traveller_tag][UNIT_TYPE] == UnitTypeId.QUEEN:

--- a/src/ares/managers/nydus_manager.py
+++ b/src/ares/managers/nydus_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any
 

--- a/src/ares/managers/path_manager.py
+++ b/src/ares/managers/path_manager.py
@@ -5,6 +5,7 @@ operations.
 """
 
 from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from cython_extensions import cy_point_below_value
@@ -39,8 +40,8 @@ class PathManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
-        config: Dict,
+        ai: AresBot,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -64,7 +65,7 @@ class PathManager(Manager, IManagerMediator):
         ]
         self.whole_map_tree: KDTree = KDTree(self.whole_map)
         # vague attempt at not recalculating np.argwhere for danger tiles
-        self.calculated_danger_tiles: list[dict[str, Union[np.ndarray, int]]] = []
+        self.calculated_danger_tiles: list[dict[str, int | np.ndarray]] = []
 
         self.manager_requests_dict = {
             ManagerRequestType.FIND_LOW_PRIORITY_PATH: lambda kwargs: (
@@ -192,7 +193,7 @@ class PathManager(Manager, IManagerMediator):
 
     def find_low_priority_path(
         self, start: Point2, target: Point2, grid: np.ndarray
-    ) -> List[Point2]:
+    ) -> list[Point2]:
         """Find several points in a path.
 
         This way a unit can queue them up all at once for performance reasons.
@@ -215,10 +216,10 @@ class PathManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Point2] :
-            List of points composing the path.
+        list[Point2] :
+            `list` of points composing the path.
         """
-        result: List[Point2] = self.map_data.pathfind(
+        result: list[Point2] = self.map_data.pathfind(
             start, target, grid, sensitivity=4
         )
 
@@ -227,7 +228,7 @@ class PathManager(Manager, IManagerMediator):
 
         idx = np.round(np.linspace(0, len(result) - 1, 8, dtype="int"))
 
-        path: List[Point2] = [result[i] for i in idx]
+        path: list[Point2] = [result[i] for i in idx]
         path.append(target)
         return path
 
@@ -312,7 +313,7 @@ class PathManager(Manager, IManagerMediator):
             else:
                 return target
 
-        path: List[Point2] = self.map_data.pathfind(
+        path: list[Point2] = self.map_data.pathfind(
             start, target, grid, sensitivity=sensitivity, smoothing=smoothing
         )
         if not path or len(path) == 0:
@@ -350,7 +351,7 @@ class PathManager(Manager, IManagerMediator):
 
     def raw_pathfind(
         self, start: Point2, target: Point2, grid: np.ndarray, sensitivity: int
-    ) -> List[Point2]:
+    ) -> list[Point2]:
         """Used for finding a full path, mostly for distance checks.
 
         Parameters

--- a/src/ares/managers/path_manager.py
+++ b/src/ares/managers/path_manager.py
@@ -4,7 +4,7 @@ This manager handles path finding and coordinates with GridManager for grid-rela
 operations.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -48,11 +48,11 @@ class PathManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super().__init__(ai, config, mediator)
@@ -247,25 +247,25 @@ class PathManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        start :
+        start : Point2
             Start point of the path.
-        target :
+        target : Point2
             Desired end point of the path.
-        grid :
+        grid : np.ndarray
             The grid that should be used for pathing.
-        sensitivity :
+        sensitivity : int = 5
             Amount of points that should be skipped in the full path between tiles that
             are returned.
-        smoothing :
+        smoothing : bool = False
             Optional path smoothing where nodes are removed if it's possible to jump
             ahead some tiles in a straight line with a lower cost.
-        sense_danger :
+        sense_danger : bool = False
             Check to see if there are any dangerous tiles near the starting point. If
             this is True and there are no dangerous tiles near the starting point, the
             pathing query is skipped and the target is returned.
-        danger_distance :
+        danger_distance : int = 20.0,
             How far away from the start to look for danger.
-        danger_threshold :
+        danger_threshold : float = 5.0
             Minimum value for a tile to be considered dangerous.
 
         Returns
@@ -368,8 +368,8 @@ class PathManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Point2] :
-            List of points composing the path
+        list[Point2] :
+            `list` of points composing the path
         """
         return self.map_data.pathfind(start, target, grid, sensitivity=sensitivity)
 

--- a/src/ares/managers/path_manager.py
+++ b/src/ares/managers/path_manager.py
@@ -5,6 +5,7 @@ operations.
 """
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import numpy as np

--- a/src/ares/managers/placement_manager.py
+++ b/src/ares/managers/placement_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 import time
 from collections import defaultdict
@@ -87,7 +88,7 @@ class PlacementManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -95,11 +96,11 @@ class PlacementManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(PlacementManager, self).__init__(ai, config, mediator)

--- a/src/ares/managers/placement_manager.py
+++ b/src/ares/managers/placement_manager.py
@@ -3,16 +3,7 @@ import time
 from collections import defaultdict
 from itertools import product
 from os import getcwd, path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    DefaultDict,
-    FrozenSet,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Coroutine
 
 import numpy as np
 from cython_extensions import (
@@ -163,7 +154,7 @@ class PlacementManager(Manager, IManagerMediator):
         )
 
         self._user_placements: dict = config_parser.parse()
-        self._gatekeeper_positions: DefaultDict[Point2, list[Point2]] = defaultdict(
+        self._gatekeeper_positions: defaultdict[Point2, list[Point2]] = defaultdict(
             list
         )
 
@@ -173,7 +164,7 @@ class PlacementManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Optional[Union[dict, DefaultDict, Coroutine[Any, Any, bool]]]:
+    ) -> dict | defaultdict | Coroutine[Any, Any, bool] | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -190,7 +181,7 @@ class PlacementManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
+        dict | defaultdict | Coroutine[Any, Any, bool] | None :
             Everything that could possibly be returned from the Manager fits in there
 
         """
@@ -319,7 +310,7 @@ class PlacementManager(Manager, IManagerMediator):
         reserve_placement: bool = True,
         within_psionic_matrix: bool = False,
         pylon_build_progress: float = 1.0,
-        closest_to: Optional[Point2] = None,
+        closest_to: Point2 | None = None,
         supply_depot: bool = False,
         production: bool = False,
         upgrade_structure: bool = False,
@@ -327,7 +318,7 @@ class PlacementManager(Manager, IManagerMediator):
         sensor_tower: bool = False,
         bunker: bool = False,
         reaper_wall: bool = False,
-    ) -> Optional[Point2]:
+    ) -> Point2 | None:
         """Given a base location and building size find an available placement."""
         assert (
             self.ai.race != Race.Zerg
@@ -554,7 +545,7 @@ class PlacementManager(Manager, IManagerMediator):
                     **placement_flags,
                 )
 
-        first_pylon_pos: Optional[Point2] = None
+        first_pylon_pos: Point2 | None = None
 
         for building, positions in building_location_info.items():
             if building in {
@@ -739,7 +730,7 @@ class PlacementManager(Manager, IManagerMediator):
         base_location: Point2,
         pylon_build_progress: float,
         closest_to: Point2,
-    ) -> Optional[Point2]:
+    ) -> Point2 | None:
         pylons = self.manager_mediator.get_own_structures_dict[UnitTypeId.PYLON]
         # first we check for ready pylons
         if available := [
@@ -1287,7 +1278,7 @@ class PlacementManager(Manager, IManagerMediator):
         The pylon position
         """
         pylon_pos: Point2 = self.ai.main_base_ramp.protoss_wall_pylon
-        buildings: FrozenSet[Point2] = self.ai.main_base_ramp.protoss_wall_buildings
+        buildings: frozenset[Point2] = self.ai.main_base_ramp.protoss_wall_buildings
 
         self._add_placement_position(
             BuildingSize.TWO_BY_TWO, el, pylon_pos, wall=True, production_pylon=True

--- a/src/ares/managers/placement_manager.py
+++ b/src/ares/managers/placement_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import math
 import time
 from collections import defaultdict

--- a/src/ares/managers/placement_manager.py
+++ b/src/ares/managers/placement_manager.py
@@ -1280,7 +1280,9 @@ class PlacementManager(Manager, IManagerMediator):
         The pylon position
         """
         pylon_pos: Point2 = self.ai.main_base_ramp.protoss_wall_pylon
-        buildings: frozenset[Point2] = self.ai.main_base_ramp.protoss_wall_buildings
+        buildings: frozenset[Point2] = frozenset(
+            self.ai.main_base_ramp.protoss_wall_buildings
+        )
 
         self._add_placement_position(
             BuildingSize.TWO_BY_TWO, el, pylon_pos, wall=True, production_pylon=True

--- a/src/ares/managers/resource_manager.py
+++ b/src/ares/managers/resource_manager.py
@@ -1,6 +1,7 @@
 """Anything to do with resource management and collection."""
 
 from __future__ import annotations
+
 import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any

--- a/src/ares/managers/resource_manager.py
+++ b/src/ares/managers/resource_manager.py
@@ -1,5 +1,6 @@
 """Anything to do with resource management and collection."""
 
+from __future__ import annotations
 import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
@@ -43,7 +44,7 @@ class ResourceManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -51,16 +52,12 @@ class ResourceManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(ResourceManager, self).__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -128,11 +125,7 @@ class ResourceManager(Manager, IManagerMediator):
         self.initial_worker_split: bool = True
 
     def set_worker_per_gas(self, amount: int) -> None:
-        """Sets how many workers to be assigned to each gas building
-
-        Returns
-        -------
-        """
+        """Sets how many workers to be assigned to each gas building"""
         self.workers_per_gas = amount
 
     @property_cache_once_per_frame
@@ -943,8 +936,12 @@ class ResourceManager(Manager, IManagerMediator):
 
         """
         if self.ai.state.game_loop == 6720:
-            print(f"{self.ai.time_formatted} Mined a total of {int(self.ai.minerals)}\
-                 minerals")
+            print(
+                f"{self.ai.time_formatted} Mined a total of {int(self.ai.minerals)}\
+                 minerals"
+            )
 
-            print(f"{self.ai.time_formatted} Mined a total of\
-                 {int(self.ai.state.score.collected_vespene)} vespene")
+            print(
+                f"{self.ai.time_formatted} Mined a total of\
+                 {int(self.ai.state.score.collected_vespene)} vespene"
+            )

--- a/src/ares/managers/resource_manager.py
+++ b/src/ares/managers/resource_manager.py
@@ -2,7 +2,7 @@
 
 import math
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from cython_extensions import (
@@ -43,8 +43,8 @@ class ResourceManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -104,22 +104,22 @@ class ResourceManager(Manager, IManagerMediator):
         self.cached_townhalls: Units = Units([], self.ai)
 
         self.workers_per_gas: int = 3
-        self.worker_to_mineral_patch_dict: Dict[int, int] = {}
-        self.mineral_patch_to_list_of_workers: Dict[int, Set[int]] = {}
+        self.worker_to_mineral_patch_dict: dict[int, int] = {}
+        self.mineral_patch_to_list_of_workers: dict[int, set[int]] = {}
 
-        self.worker_to_geyser_dict: Dict[int, int] = {}
-        self.geyser_to_list_of_workers: Dict[int, Set[int]] = {}
+        self.worker_to_geyser_dict: dict[int, int] = {}
+        self.geyser_to_list_of_workers: dict[int, set[int]] = {}
 
-        self.mineral_tag_to_mineral: Dict[int, Unit] = {}
-        self.mineral_object_to_worker_units_object: DefaultDict[Unit, List[Unit]] = (
-            defaultdict(list)
-        )
+        self.mineral_tag_to_mineral: dict[int, Unit] = {}
+        self.mineral_object_to_worker_units_object: defaultdict[
+            Unit, list[Unit]
+        ] = defaultdict(list)
         # keep track of how many mineral patches we have available
         self.num_available_min_patches: int = 0
         # mineral targets are positions just before the mineral (for speed mining)
-        self.mineral_target_dict: Dict[Point2, Point2] = {}
+        self.mineral_target_dict: dict[Point2, Point2] = {}
         # store which townhall the worker is closest to
-        self.worker_tag_to_townhall_tag: Dict[int, int] = {}
+        self.worker_tag_to_townhall_tag: dict[int, int] = {}
         if not self.ai.arcade_mode:
             self._calculate_mineral_targets()
 
@@ -326,7 +326,7 @@ class ResourceManager(Manager, IManagerMediator):
         only_select_persistent_builder: bool = False,
         min_health_perc: float = 0.0,
         min_shield_perc: float = 0.0,
-    ) -> Optional[Unit]:
+    ) -> Unit | None:
         """Select a worker.
 
         This way we can select one assigned to a far mineral patch.
@@ -355,7 +355,7 @@ class ResourceManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Unit] :
+        Unit | None :
             Selected worker, if available.
 
         """
@@ -528,7 +528,7 @@ class ResourceManager(Manager, IManagerMediator):
                 continue
 
             # Assign worker closest to the gas building
-            worker: Optional[Unit] = self.select_worker(gas.position, force_close=True)
+            worker: Unit | None = self.select_worker(gas.position, force_close=True)
 
             if not worker or worker.tag in self.geyser_to_list_of_workers:
                 continue
@@ -796,8 +796,8 @@ class ResourceManager(Manager, IManagerMediator):
             }
 
     def _create_resource_to_worker_object_dict(
-        self, resource_dict: Dict[int, Unit], resource_type: str
-    ) -> Dict[Unit, Units]:
+        self, resource_dict: dict[int, Unit], resource_type: str
+    ) -> dict[Unit, Units]:
         """Create dictionary where
 
         The key is a mineral field or gas building and tag the value is a Units of
@@ -812,19 +812,19 @@ class ResourceManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Dict[Unit, Units] :
+        dict[Unit, Units] :
             Resource Unit to Units of Workers mining it
 
         """
-        resource_to_workers: DefaultDict[Unit, List[Unit]] = defaultdict(list)
+        resource_to_workers: defaultdict[Unit, list[Unit]] = defaultdict(list)
         if resource_type == MINERAL:
-            worker_to_resource: Dict[int, int] = self.worker_to_mineral_patch_dict
+            worker_to_resource: dict[int, int] = self.worker_to_mineral_patch_dict
         else:
-            worker_to_resource: Dict[int, int] = self.worker_to_geyser_dict
+            worker_to_resource: dict[int, int] = self.worker_to_geyser_dict
         for worker in self.ai.workers:
             if worker.tag in worker_to_resource:
                 resource_tag: int = worker_to_resource[worker.tag]
-                resource_object: Optional[Unit] = resource_dict.get(resource_tag, None)
+                resource_object: Unit | None = resource_dict.get(resource_tag, None)
                 if resource_object is None:
                     if resource_type == MINERAL:
                         self._remove_mineral_field(resource_tag)
@@ -895,7 +895,7 @@ class ResourceManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Point2] :
+        list[Point2] :
             The intersection points of the circles.
 
         """

--- a/src/ares/managers/squad_manager.py
+++ b/src/ares/managers/squad_manager.py
@@ -2,7 +2,7 @@
 
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from cython_extensions import cy_center, cy_distance_to_squared
 from sc2.ids.unit_typeid import UnitTypeId
@@ -32,7 +32,7 @@ class UnitSquad:
     squad_position : Point2
         The position where this group is situated.
     squad_units : list[Unit]
-        List of units for this group. Ideally this should
+        `list` of `Unit`s for this group. Ideally this should
         be updated with fresh Unit objects every step/frame.
     tags : set[int]
         Tags of all units that belong to this squad.
@@ -113,7 +113,7 @@ class SquadManager(Manager, IManagerMediator):
 
         self._assigned_unit_tags: set[int] = set()
         # self._squads: dict[UnitRole, list[UnitSquad]] = defaultdict(list)
-        # key -> UnitRole, value -> Dict[key -> squad_id, value -> tags, squad object]
+        # key -> UnitRole, value -> dict[key -> squad_id, value -> tags, squad object]
         self._squads_dict: dict[UnitRole, dict[str, Any]] = {
             role: {} for role in UnitRole
         }
@@ -190,7 +190,7 @@ class SquadManager(Manager, IManagerMediator):
         self,
         role: UnitRole,
         squad_radius: float = 6.0,
-        unit_type: Optional[Union[UnitTypeId, set[UnitTypeId]]] = None,
+        unit_type: UnitTypeId | set[UnitTypeId] | None = None,
     ) -> list[UnitSquad]:
         """
         The main entry point to this manager. Since we do not want

--- a/src/ares/managers/squad_manager.py
+++ b/src/ares/managers/squad_manager.py
@@ -1,5 +1,6 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
+from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -81,7 +82,7 @@ class SquadManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -89,16 +90,12 @@ class SquadManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {

--- a/src/ares/managers/squad_manager.py
+++ b/src/ares/managers/squad_manager.py
@@ -1,6 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
 from __future__ import annotations
+
 import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any

--- a/src/ares/managers/terrain_manager.py
+++ b/src/ares/managers/terrain_manager.py
@@ -1,6 +1,7 @@
 """Calculations involving terrain."""
 
 from __future__ import annotations
+
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 

--- a/src/ares/managers/terrain_manager.py
+++ b/src/ares/managers/terrain_manager.py
@@ -1,5 +1,6 @@
 """Calculations involving terrain."""
 
+from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -53,24 +54,20 @@ class TerrainManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
-        """Set up the manager.
+        """Sets up the manager.
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -407,15 +404,15 @@ class TerrainManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        start_point :
+        start_point : Point2
             Start flood fill outwards from this point.
-        max_dist :
+        max_dist : int = 25
             Distance from start point before finishing the algorithm.
 
         Returns
         -------
         set :
-            Set of points (as tuples) that are filled in
+            `set` of points (as `tuples`) that are filled in.
         """
         all_points = cy_flood_fill_grid(
             start_point=start_point.rounded,

--- a/src/ares/managers/terrain_manager.py
+++ b/src/ares/managers/terrain_manager.py
@@ -1,7 +1,7 @@
 """Calculations involving terrain."""
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from cython_extensions import cy_flood_fill_grid, cy_towards
@@ -46,15 +46,15 @@ class TerrainManager(Manager, IManagerMediator):
 
     CANT_BUILD_LOCATION_INVALID: int = 44
     cached_pathing_grid: np.ndarray
-    choke_points: Set[Point2]
+    choke_points: set[Point2]
     current_siege_point: Point2
     current_siege_target: Point2
     map_data: MapData
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -113,16 +113,16 @@ class TerrainManager(Manager, IManagerMediator):
         }
 
         self.debug: bool = self.config[DEBUG]
-        self.own_expansions: List[Tuple[Point2, float]] = []
-        self.enemy_expansions: List[Tuple[Point2, float]] = []
-        self.positions_blocked_by_enemy_burrowed_units: List[Point2] = []
+        self.own_expansions: list[tuple[Point2, float]] = []
+        self.enemy_expansions: list[tuple[Point2, float]] = []
+        self.positions_blocked_by_enemy_burrowed_units: list[Point2] = []
 
         self.initial_pathing_grid: np.ndarray = (
             self.ai.game_info.pathing_grid.data_numpy.copy()
         )
 
         # needed a place to track spines until the spine positioning manager is done
-        self.base_defense_spine_positions: Dict[Point2, int] = {}
+        self.base_defense_spine_positions: dict[Point2, int] = {}
 
     def initialise(self) -> None:
         """Calculate expansion locations from own and enemy perspective.
@@ -141,7 +141,7 @@ class TerrainManager(Manager, IManagerMediator):
             )
 
         self.map_data = self.manager_mediator.get_map_data_object
-        self.choke_points: Set[Point2] = set(
+        self.choke_points: set[Point2] = set(
             [point for ch in self.map_data.map_chokes for point in ch.points]
         )
 
@@ -306,13 +306,13 @@ class TerrainManager(Manager, IManagerMediator):
         return False
 
     @cached_property
-    def ol_spots(self) -> List[Point2]:
+    def ol_spots(self) -> list[Point2]:
         """High ground Overlord hiding spots.
 
         Returns
         -------
-        List[Point2] :
-            List of Overlord hiding spots.
+        list[Point2] :
+            `list` of Overlord hiding spots.
 
         """
         return [Point2(tuple_spot) for tuple_spot in self.map_data.overlord_spots]
@@ -479,7 +479,7 @@ class TerrainManager(Manager, IManagerMediator):
 
     def building_position_blocked_by_burrowed_unit(
         self, worker_tag: int, position: Point2
-    ) -> Optional[Point2]:
+    ) -> Point2 | None:
         """See if the building position is blocked by a burrowed unit.
 
         Parameters
@@ -491,7 +491,7 @@ class TerrainManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Point2] :
+        Point2 | None :
             The position that's blocked by an enemy unit.
 
         """
@@ -517,7 +517,7 @@ class TerrainManager(Manager, IManagerMediator):
 
     def _calculate_expansion_path_distances(
         self, from_pos: Point2
-    ) -> List[Tuple[Point2, float]]:
+    ) -> list[tuple[Point2, float]]:
         """Calculates pathing distances to all expansions on the map
         from a given map position, returns list of expansions in order
         of pathing distance from from_pos
@@ -530,13 +530,13 @@ class TerrainManager(Manager, IManagerMediator):
 
         Returns
         -------
-        expansion_distances : List[Tuple[Point2, float]]
-            List of Tuples where
+        expansion_distances : list[tuple[Point2, float]]
+            list of tuples where
                 The first element is the location of the base.
                 The second element is the pathing distance from `from_pos`.
 
         """
-        expansion_distances: List[Tuple[Point2, float]] = []
+        expansion_distances: list[tuple[Point2, float]] = []
         grid: np.ndarray = self.manager_mediator.get_ground_grid
         for el in self.ai.expansion_locations_list:
             if from_pos.distance_to(el) < self.ai.EXPANSION_GAP_THRESHOLD:
@@ -551,7 +551,7 @@ class TerrainManager(Manager, IManagerMediator):
         expansion_distances = sorted(expansion_distances, key=lambda x: x[1])
         return expansion_distances
 
-    def get_behind_mineral_positions(self, th_pos: Point2) -> List[Point2]:
+    def get_behind_mineral_positions(self, th_pos: Point2) -> list[Point2]:
         """Finds 3 spots behind the mineral line
 
         Notes
@@ -565,12 +565,12 @@ class TerrainManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Point2] :
+        list[Point2] :
             Points behind the mineral line of the designated base.
 
         """
-        positions: List[Point2] = []
-        possible_behind_mineral_positions: List[Point2] = []
+        positions: list[Point2] = []
+        possible_behind_mineral_positions: list[Point2] = []
 
         all_mf: Units = self.ai.mineral_field.closer_than(10, th_pos)
 
@@ -591,14 +591,14 @@ class TerrainManager(Manager, IManagerMediator):
 
         return positions
 
-    def get_base_to_choke_information(self) -> Dict[Point2, Dict[ChokeArea, int]]:
+    def get_base_to_choke_information(self) -> dict[Point2, dict[ChokeArea, int]]:
         """Get pathing distance from each base to every choke point on the map.
 
         VisionBlockerArea chokes are currently ignored.
 
         Returns
         -------
-        Dict[Point2, Dict[ChokeArea, int]] :
+        dict[Point2, dict[ChokeArea, int]] :
             Key is the base location
             Value is a dictionary where the key is the choke point and the value is the
                 length of the path to that choke point.
@@ -629,7 +629,7 @@ class TerrainManager(Manager, IManagerMediator):
         -------
 
         """
-        _positions_blocked_by_enemy_burrowed_units: List[Point2] = []
+        _positions_blocked_by_enemy_burrowed_units: list[Point2] = []
         for position in self.positions_blocked_by_enemy_burrowed_units:
             detectors: Units = self.manager_mediator.get_units_in_range(
                 start_points=[position], distance=7, query_tree=UnitTreeQueryType.AllOwn

--- a/src/ares/managers/unit_cache_manager.py
+++ b/src/ares/managers/unit_cache_manager.py
@@ -1,6 +1,7 @@
 """Cache armies for better and faster tracking."""
 
 from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 

--- a/src/ares/managers/unit_cache_manager.py
+++ b/src/ares/managers/unit_cache_manager.py
@@ -1,5 +1,6 @@
 """Cache armies for better and faster tracking."""
 
+from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -37,7 +38,7 @@ class UnitCacheManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -45,16 +46,12 @@ class UnitCacheManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {

--- a/src/ares/managers/unit_cache_manager.py
+++ b/src/ares/managers/unit_cache_manager.py
@@ -1,7 +1,7 @@
 """Cache armies for better and faster tracking."""
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+from typing import TYPE_CHECKING, Any
 
 from cython_extensions import cy_unit_pending
 from sc2.data import Race
@@ -37,8 +37,8 @@ class UnitCacheManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -86,8 +86,8 @@ class UnitCacheManager(Manager, IManagerMediator):
         self.enemy_army: Units = Units([], ai)
         self.enemy_workers: Units = Units([], ai)
         self.own_army: Units = Units([], ai)
-        self.enemy_army_tags: Set[int] = set()
-        self.enemy_worker_tags: Set[int] = set()
+        self.enemy_army_tags: set[int] = set()
+        self.enemy_worker_tags: set[int] = set()
         # keep a dict of units for fast lookup
         # caution: this is for bookkeeping only,
         # don't use distance checks here for example
@@ -96,11 +96,11 @@ class UnitCacheManager(Manager, IManagerMediator):
         # used for assigning roles to locusts, may not be useful
         self.old_own_army: defaultdict[UnitTypeId, list] = defaultdict(list)
         self.own_structures_dict: defaultdict[UnitTypeId, list] = defaultdict(list)
-        self.own_structure_tags: Set = set()
+        self.own_structure_tags: set = set()
         # keep track of units that get removed, so they can be deleted from memory units
         self.removed_units: Units = Units([], ai)
         # keep track of unit tags we want to remove, so we can do it in one operation
-        self.enemy_tags_to_remove: Set[int] = set()
+        self.enemy_tags_to_remove: set[int] = set()
         self.enemy_army_units_to_add: Units = Units([], ai)
 
     def manager_request(
@@ -143,8 +143,8 @@ class UnitCacheManager(Manager, IManagerMediator):
 
         """
         self.removed_units: Units = Units([], self.ai)
-        self.enemy_army_tags: Set[int] = self.enemy_army.tags
-        self.enemy_worker_tags: Set[int] = self.enemy_workers.tags
+        self.enemy_army_tags: set[int] = self.enemy_army.tags
+        self.enemy_worker_tags: set[int] = self.enemy_workers.tags
 
     @property
     def enemy_army_value(self) -> int:
@@ -391,7 +391,7 @@ class UnitCacheManager(Manager, IManagerMediator):
 
         self.own_structures_dict[unit.type_id].append(unit)
 
-    def get_units_from_tags(self, tags: Union[List[int], Set[int]]) -> List[Unit]:
+    def get_units_from_tags(self, tags: list[int] | set[int]) -> list[Unit]:
         """Get a `list` of `Unit` objects corresponding to the given tags.
 
         Parameters
@@ -403,7 +403,7 @@ class UnitCacheManager(Manager, IManagerMediator):
         -------
 
         """
-        retrieved_tags: List[Unit] = []
+        retrieved_tags: list[Unit] = []
         for tag in tags:
             if tag in self.ai.unit_tag_dict:
                 unit = self.ai.unit_tag_dict[tag]

--- a/src/ares/managers/unit_memory_manager.py
+++ b/src/ares/managers/unit_memory_manager.py
@@ -1,6 +1,7 @@
 """Manager for keeping track of enemy last known positions."""
 
 from __future__ import annotations
+
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque
 

--- a/src/ares/managers/unit_memory_manager.py
+++ b/src/ares/managers/unit_memory_manager.py
@@ -1,7 +1,7 @@
 """Manager for keeping track of enemy last known positions."""
 
 from collections import deque
-from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Deque
 
 import numpy as np
 from cython_extensions import cy_distance_to
@@ -37,8 +37,8 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
-        config: Dict,
+        ai: AresBot,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -77,13 +77,13 @@ class UnitMemoryManager(Manager, IManagerMediator):
         # Dictionary of units that we remember the position of. Keyed by unit tag.
         # Deque is used so that new snapshots are added to the left, and old ones are
         # removed from the right.
-        self._memory_units_by_tag: Dict[int, Deque[Unit]] = {}
+        self._memory_units_by_tag: dict[int, Deque[Unit]] = {}
 
         # Dictionary of units that we know of, but which are longer present at the
         # location last seen. Keyed by unit tag
-        self._archive_units_by_tag: Dict[int, Deque[Unit]] = {}
+        self._archive_units_by_tag: dict[int, Deque[Unit]] = {}
         self._tags_destroyed: set[int] = set()
-        self.unit_dict: Dict[int, Deque[Unit]] = {}
+        self.unit_dict: dict[int, Deque[Unit]] = {}
 
         # remove units from memory after <time_in_seconds> based on air or ground
         self.expire_air: int = 30
@@ -94,10 +94,10 @@ class UnitMemoryManager(Manager, IManagerMediator):
         self.all_enemies: Units = self.ai.all_enemy_units
         self.enemy_ground: Units = Units([], self.ai)
         self.enemy_fliers: Units = Units([], self.ai)
-        self.enemy_tree: Optional[KDTree] = None
-        self.own_tree: Optional[KDTree] = None
-        self.enemy_ground_tree: Optional[KDTree] = None
-        self.enemy_air_tree: Optional[KDTree] = None
+        self.enemy_tree: KDTree | None = None
+        self.own_tree: KDTree | None = None
+        self.enemy_ground_tree: KDTree | None = None
+        self.enemy_air_tree: KDTree | None = None
 
         # empty units, so we don't have to generate it ten billion times
         self.empty_units: Units = Units([], self.ai)
@@ -105,19 +105,18 @@ class UnitMemoryManager(Manager, IManagerMediator):
     @property_cache_once_per_frame
     def enemy_detectors_and_ranges(
         self,
-    ) -> Tuple[List[Union[Point2, List[float]]], List[float]]:
+    ) -> tuple[list[Point2 | list[float]], list[float]]:
         """Cached unit positions and ranges for enemy detector.
 
         Returns
         -------
-        Tuple[List[Union[Point2, List[float]]], List[float]] :
+        tuple[list[Point2 | list[float]], list[float]] :
             First element is a `list` of detector positions.
             Second element is a `list` of detector ranges.
-
         """
         # get the positions and ranges
-        enemy_detector_position: List[Union[Point2, List[float]]] = []
-        enemy_detector_range: List[float] = []
+        enemy_detector_position: list[Point2 | list[float]] = []
+        enemy_detector_range: list[float] = []
 
         for effect in self.ai.state.effects:
             if effect.id in DETECTOR_RANGES:
@@ -169,7 +168,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
         -------
 
         """
-        memory_tags_to_remove: List[int] = []
+        memory_tags_to_remove: list[int] = []
         removed_unit_tags: set[int] = self.manager_mediator.manager_request(
             ManagerName.UNIT_CACHE_MANAGER, ManagerRequestType.GET_REMOVED_UNITS
         ).tags
@@ -182,7 +181,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
                 continue
 
             snap = self.get_latest_snapshot(unit_tag)
-            points: List[Point2] = [
+            points: list[Point2] = [
                 Point2((int(snap.position.x), int(snap.position.y))),
                 Point2((int(snap.position.x + 1), int(snap.position.y))),
                 Point2((int(snap.position.x), int(snap.position.y + 1))),
@@ -373,7 +372,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
             return snap.age > self.expire_air
         return snap.age > self.expire_ground
 
-    def clear_unit_cache(self, memory_tags_to_remove: List[int], unit_tag: int) -> None:
+    def clear_unit_cache(self, memory_tags_to_remove: list[int], unit_tag: int) -> None:
         """Clear the cache of the unit and archive it.
 
         Parameters
@@ -404,8 +403,8 @@ class UnitMemoryManager(Manager, IManagerMediator):
         self.enemy_ground_tree = self._create_tree(self.enemy_ground)
 
     @staticmethod
-    def _create_tree(units: Units) -> Optional[KDTree]:
-        unit_position_list: List[List[float]] = [
+    def _create_tree(units: Units) -> KDTree | None:
+        unit_position_list: list[list[float]] = [
             [unit.position.x, unit.position.y] for unit in units
         ]
         if unit_position_list:
@@ -415,11 +414,11 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
     def units_in_range(
         self,
-        start_points: List[Union[Unit, Tuple[float, float]]],
-        distances: Union[float, List[float]],
+        start_points: list[Unit | tuple[float, float] | Point2],
+        distances: float | list[float],
         query_tree: UnitTreeQueryType,
         return_as_dict: bool = False,
-    ) -> Union[Dict[Union[Point2, int], Units], List[Units]]:
+    ) -> dict[int | Point2, Units] | list[Units]:
         """Get units within range of each `Unit` or `Point2` in `start_points`.
 
         Notes
@@ -428,9 +427,9 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        start_points: List[Union[Unit, Tuple[float, float]]]
-            List of `Unit`s or positions to search for units from.
-        distances: Union[float, List[float]]
+        start_points: list[Unit | tuple[float, float]]
+            `list` of `Unit`s or positions to search for units from.
+        distances: float | list[float]
             How far away from each point to query.
         query_tree: UnitTreeQueryType
             Which KDTree should be queried.
@@ -439,7 +438,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Union[Dict[Union[int, Tuple[float, float]], Units], List[Units]] :
+        dict[int | Point2, Units] | list[Units] :
             Returns the units in range of each start point as a `dict` where the key
             is the unit tag or position and the value is the `Units` in range or a
             `list` of `Units`.
@@ -450,7 +449,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
         if tree is None:
             in_range_list = [self.empty_units for _ in range(len(start_points))]
         else:
-            in_range_list: List[Units] = []
+            in_range_list: list[Units] = []
             if start_points:
                 positions = [
                     u.position if isinstance(u, Unit) else u for u in start_points
@@ -477,7 +476,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
     def _get_tree_and_unit_container(
         self, requested_query_type: UnitTreeQueryType
-    ) -> Tuple[KDTree, Units]:
+    ) -> tuple[KDTree, Units]:
         """Get the trees and unit containers based on query type.
 
         Parameters
@@ -487,7 +486,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Tuple[KDTree, Units] :
+        tuple[KDTree, Units] :
             First element is the KDTree to query.
             Second element is the units that make up that KDTree.
 
@@ -504,8 +503,8 @@ class UnitMemoryManager(Manager, IManagerMediator):
             raise ValueError(f"Unsupported query type: {requested_query_type}")
 
     def any_enemies_in_range(
-        self, positions: Union[List[Point2], List[List[float]]], radius: float
-    ) -> List[bool]:
+        self, positions: list[Point2] | list[list[float]], radius: float
+    ) -> list[bool]:
         """Check if any enemies are in range of a list of points.
 
         Parameters
@@ -517,7 +516,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[bool] :
+        list[bool] :
             True or False for each point in the list depending on if any enemy
             units are present within radius.
 
@@ -617,14 +616,13 @@ class UnitMemoryManager(Manager, IManagerMediator):
         Set[int] :
             Set of tags of our units that are in range of a detector. This doesn't take
             our unit's radius into account, only the radius of the detector.
-
         """
         # skip if we don't have units
         if self.own_tree is None:
             return set()
 
         # need to get a set eventually, but lists are faster to add to
-        unit_tags_in_range_list: List[int] = []
+        unit_tags_in_range_list: list[int] = []
 
         # get the positions and ranges
         enemy_detector_position, enemy_detector_range = self.enemy_detectors_and_ranges

--- a/src/ares/managers/unit_memory_manager.py
+++ b/src/ares/managers/unit_memory_manager.py
@@ -1,5 +1,6 @@
 """Manager for keeping track of enemy last known positions."""
 
+from __future__ import annotations
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque
 
@@ -613,7 +614,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Set[int] :
+        unit_tags_in_range_list : set[int]
             Set of tags of our units that are in range of a detector. This doesn't take
             our unit's radius into account, only the radius of the detector.
         """

--- a/src/ares/managers/unit_role_manager.py
+++ b/src/ares/managers/unit_role_manager.py
@@ -1,6 +1,6 @@
 """Manage assigning/removing of roles and getting units by role."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from sc2.ids.unit_typeid import UnitTypeId
@@ -36,7 +36,7 @@ class UnitRoleManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        config: Dict,
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -44,16 +44,12 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(UnitRoleManager, self).__init__(ai, config, mediator)
         self.unit_role_dict: dict[str, set[int]] = {
@@ -204,14 +200,10 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        tags :
+        tags : list[int] | set[int]
             Tags of the units to assign to a role.
-        role :
+        role : UnitRole
             The role the units should be assigned to.
-
-        Returns
-        -------
-
         """
         for tag in tags:
             self.assign_role(tag, role)
@@ -241,12 +233,8 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        tags :
+        tags : set[int]
             Tags of the units to clear the roles of.
-
-        Returns
-        -------
-
         """
         for tag in tags:
             self.clear_role(tag)

--- a/src/ares/managers/unit_role_manager.py
+++ b/src/ares/managers/unit_role_manager.py
@@ -1,6 +1,7 @@
 """Manage assigning/removing of roles and getting units by role."""
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any
 
 from sc2.ids.unit_typeid import UnitTypeId
 from sc2.unit import Unit
@@ -26,17 +27,17 @@ class UnitRoleManager(Manager, IManagerMediator):
     themselves.
     """
 
-    LOCUSTS: Set[UnitTypeId] = {UnitTypeId.LOCUSTMP, UnitTypeId.LOCUSTMPFLYING}
-    SQUAD_ROLES: Set[UnitRole] = {UnitRole.ATTACKING}
-    ZERG_STATIC_DEFENCE: Set[UnitTypeId] = {
+    LOCUSTS: set[UnitTypeId] = {UnitTypeId.LOCUSTMP, UnitTypeId.LOCUSTMPFLYING}
+    SQUAD_ROLES: set[UnitRole] = {UnitRole.ATTACKING}
+    ZERG_STATIC_DEFENCE: set[UnitTypeId] = {
         UnitTypeId.SPINECRAWLER,
         UnitTypeId.SPORECRAWLER,
     }
 
     def __init__(
         self,
-        ai: "AresBot",
         config: Dict,
+        config: dict,
         mediator: ManagerMediator,
     ) -> None:
         """Set up the manager.
@@ -55,10 +56,10 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         """
         super(UnitRoleManager, self).__init__(ai, config, mediator)
-        self.unit_role_dict: Dict[str, Set[int]] = {
+        self.unit_role_dict: dict[str, set[int]] = {
             role.name: set() for role in UnitRole
         }
-        self.tag_to_role_dict: Dict[int, str] = {}
+        self.tag_to_role_dict: dict[int, str] = {}
         self.manager_requests_dict = {
             ManagerRequestType.ASSIGN_ROLE: lambda kwargs: self.assign_role(**kwargs),
             ManagerRequestType.BATCH_ASSIGN_ROLE: lambda kwargs: self.batch_assign_role(
@@ -77,7 +78,7 @@ class UnitRoleManager(Manager, IManagerMediator):
             ),
             ManagerRequestType.SWITCH_ROLES: lambda kwargs: self.switch_roles(**kwargs),
         }
-        self.all_assigned_tags: Set[int] = set()
+        self.all_assigned_tags: set[int] = set()
 
     def manager_request(
         self,
@@ -143,7 +144,7 @@ class UnitRoleManager(Manager, IManagerMediator):
         -------
 
         """
-        assigned_tags_list: List[int] = []
+        assigned_tags_list: list[int] = []
         for role in self.unit_role_dict:
             assigned_tags_list += self.unit_role_dict[role]
         self.all_assigned_tags = set(assigned_tags_list)
@@ -194,10 +195,8 @@ class UnitRoleManager(Manager, IManagerMediator):
         if remove_from_squad:
             self.manager_mediator.remove_tag_from_squads(tag=tag)
 
-    def batch_assign_role(
-        self, tags: Union[List[int], Set[int]], role: UnitRole
-    ) -> None:
-        """Assign a given role to a List of unit tags.
+    def batch_assign_role(self, tags: list[int] | set[int], role: UnitRole) -> None:
+        """Assign a given role to a `list` of unit tags.
 
         Notes
         -----
@@ -233,8 +232,8 @@ class UnitRoleManager(Manager, IManagerMediator):
             if tag in self.unit_role_dict[role]:
                 self.unit_role_dict[role].remove(tag)
 
-    def batch_clear_role(self, tags: Set[int]) -> None:
-        """Clear the roles of a given List of unit tags.
+    def batch_clear_role(self, tags: set[int]) -> None:
+        """Clear the roles of a given `set` of unit tags.
 
         Notes
         -----
@@ -255,8 +254,8 @@ class UnitRoleManager(Manager, IManagerMediator):
     def get_units_from_role(
         self,
         role: UnitRole,
-        unit_type: Optional[Union[UnitTypeId, Set[UnitTypeId]]] = None,
-        restrict_to: Optional[Units] = None,
+        unit_type: UnitTypeId | set[UnitTypeId] | None = None,
+        restrict_to: Units | None = None,
     ) -> Units:
         """Get a Units object containing units with a given role.
 
@@ -292,7 +291,7 @@ class UnitRoleManager(Manager, IManagerMediator):
             else:
                 # will crash if not an iterable but we should be careful with typing
                 # anyway
-                retrieved_units: List[Unit] = []
+                retrieved_units: list[Unit] = []
                 for type_id in unit_type:
                     retrieved_units.extend(
                         self.get_single_type_from_single_role(
@@ -303,12 +302,12 @@ class UnitRoleManager(Manager, IManagerMediator):
         else:
             # get every unit with the role
             if restrict_to:
-                tags_to_get: Set[int] = (
+                tags_to_get: set[int] = (
                     self.unit_role_dict[role.name] & restrict_to.tags
                 )
             else:
-                tags_to_get: Set[int] = self.unit_role_dict[role.name]
-            # get the List[Unit] from UnitCacheManager and return as Units
+                tags_to_get: set[int] = self.unit_role_dict[role.name]
+            # get the list[Unit] from UnitCacheManager and return as Units
             return Units(
                 self.manager_mediator.manager_request(
                     ManagerName.UNIT_CACHE_MANAGER,
@@ -320,8 +319,8 @@ class UnitRoleManager(Manager, IManagerMediator):
 
     def get_units_from_roles(
         self,
-        roles: Set[UnitRole],
-        unit_type: Union[None, UnitTypeId, Set[UnitTypeId]] = None,
+        roles: set[UnitRole],
+        unit_type: UnitTypeId | set[UnitTypeId] | None = None,
     ) -> Units:
         """Get the units matching `unit_type` from the given roles.
 
@@ -361,7 +360,7 @@ class UnitRoleManager(Manager, IManagerMediator):
         self.batch_assign_role(self.get_units_from_role(from_role).tags, to_role)
 
     def get_all_from_roles_except(
-        self, roles: Set[UnitRole], excluded: Set[UnitTypeId]
+        self, roles: set[UnitRole], excluded: set[UnitTypeId]
     ) -> Units:
         """Get all units from the given roles except for unit types in excluded.
 
@@ -378,21 +377,21 @@ class UnitRoleManager(Manager, IManagerMediator):
             Units matching the role that are not of an excluded type.
 
         """
-        role_tags: List[int] = []
-        valid_tags: List[int] = []
+        role_tags: list[int] = []
+        valid_tags: list[int] = []
         # get a list of the tags of the units in the given roles
         for role in roles:
             role_tags.extend(self.unit_role_dict[role.name])
         # convert to a set for faster lookup
-        role_set: Set[int] = set(role_tags)
-        own_army_dict: Dict = self.manager_mediator.manager_request(
+        role_set: set[int] = set(role_tags)
+        own_army_dict: dict = self.manager_mediator.manager_request(
             ManagerName.UNIT_CACHE_MANAGER, ManagerRequestType.GET_CACHED_OWN_ARMY_DICT
         )
         # get the tags of all units that aren't of the excluded types
         for unit_type in own_army_dict:
             if unit_type not in excluded:
                 valid_tags.extend(own_army_dict[unit_type].tags)
-        shared_tags: List[int] = [tag for tag in valid_tags if tag in role_set]
+        shared_tags: list[int] = [tag for tag in valid_tags if tag in role_set]
         return Units(
             self.manager_mediator.manager_request(
                 ManagerName.UNIT_CACHE_MANAGER,
@@ -403,8 +402,8 @@ class UnitRoleManager(Manager, IManagerMediator):
         )
 
     def get_single_type_from_single_role(
-        self, unit_type: UnitTypeId, role: UnitRole, restrict_to: Optional[Units] = None
-    ) -> List[Unit]:
+        self, unit_type: UnitTypeId, role: UnitRole, restrict_to: Units | None = None
+    ) -> list[Unit]:
         """Get all units of a given type that have a specified role.
 
         If restrict_to is Units, this will only get the units of the specified type and
@@ -422,7 +421,7 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Unit] :
+        list[Unit] :
             Units matching the given type with the given role.
 
         """
@@ -440,7 +439,7 @@ class UnitRoleManager(Manager, IManagerMediator):
             shared_tags: set[int] = (
                 unit_with_role_tags & units_of_type_tags & restrict_to.tags
             )
-        # get the List[Unit] from UnitCacheManager
+        # get the list[Unit] from UnitCacheManager
         return self.manager_mediator.manager_request(
             ManagerName.UNIT_CACHE_MANAGER,
             ManagerRequestType.GET_UNITS_FROM_TAGS,

--- a/src/ares/managers/unit_role_manager.py
+++ b/src/ares/managers/unit_role_manager.py
@@ -1,6 +1,7 @@
 """Manage assigning/removing of roles and getting units by role."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from sc2.ids.unit_typeid import UnitTypeId

--- a/src/ares/managers/utils/placement_strategy.py
+++ b/src/ares/managers/utils/placement_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 

--- a/src/ares/managers/utils/placement_strategy.py
+++ b/src/ares/managers/utils/placement_strategy.py
@@ -86,9 +86,9 @@ class PoweredPlacementStrategy(BasePlacementStrategy):
         two_by_twos: dict = self.placement_manager.placements_dict[building_at_base][
             BuildingSize.TWO_BY_TWO
         ]
-        placements_for_base: dict[Point2, dict] = (
-            self.placement_manager.placements_dict[building_at_base][self.building_size]
-        )
+        placements_for_base: dict[
+            Point2, dict
+        ] = self.placement_manager.placements_dict[building_at_base][self.building_size]
 
         if self.req.reaper_wall:
             available_reaper_wall = self._filter_by_flag(
@@ -174,9 +174,9 @@ class UnpoweredPlacementStrategy(BasePlacementStrategy):
         available: list[Point2],
         building_at_base: Point2,
     ) -> None | Point2:
-        placements_for_base: dict[Point2, dict] = (
-            self.placement_manager.placements_dict[building_at_base][self.building_size]
-        )
+        placements_for_base: dict[
+            Point2, dict
+        ] = self.placement_manager.placements_dict[building_at_base][self.building_size]
 
         closest_to: Point2 = (
             building_at_base if not self.req.closest_to else self.req.closest_to

--- a/src/ares/managers/utils/user_placement_extractor.py
+++ b/src/ares/managers/utils/user_placement_extractor.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.data import Race

--- a/src/ares/managers/utils/user_placement_extractor.py
+++ b/src/ares/managers/utils/user_placement_extractor.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sc2.data import Race
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 class UserPlacementExtractor:
     """Handles extraction and parsing of user-defined building placements from YAML."""
 
-    def __init__(self, ai: "AresBot", user_placements: dict):
+    def __init__(self, ai: AresBot, user_placements: dict):
         self.ai = ai
         self.user_placements = user_placements
 

--- a/src/ares/managers/warp_in_manager.py
+++ b/src/ares/managers/warp_in_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 

--- a/src/ares/managers/warp_in_manager.py
+++ b/src/ares/managers/warp_in_manager.py
@@ -1,4 +1,6 @@
 from typing import TYPE_CHECKING, Any, Coroutine, DefaultDict, Optional, Union
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Coroutine
 
 from cython_extensions.geometry import cy_distance_to_squared
 from loguru import logger
@@ -52,7 +54,7 @@ class WarpInManager(Manager, IManagerMediator):
         request: ManagerRequestType,
         reason: str = None,
         **kwargs,
-    ) -> Optional[Union[dict, DefaultDict, Coroutine[Any, Any, bool]]]:
+    ) -> dict | defaultdict | Coroutine[Any, Any, bool] | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
@@ -69,7 +71,7 @@ class WarpInManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
+        dict | defaultdict | Coroutine[Any, Any, bool] | None :
             Everything that could possibly be returned from the Manager fits in there
 
         """
@@ -90,7 +92,7 @@ class WarpInManager(Manager, IManagerMediator):
         self.requested_warp_ins = []
 
     def request_warp_in(
-        self, build_from: UnitTypeId, unit_type: UnitTypeId, target: Optional[Point2]
+        self, build_from: UnitTypeId, unit_type: UnitTypeId, target: Point2 | None
     ) -> None:
         """
         Get a warp in spot closest to target

--- a/src/ares/managers/warp_in_manager.py
+++ b/src/ares/managers/warp_in_manager.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Coroutine, DefaultDict, Optional, Union
+from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 
@@ -22,7 +22,7 @@ class WarpInManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -30,11 +30,11 @@ class WarpInManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(WarpInManager, self).__init__(ai, config, mediator)
@@ -119,9 +119,9 @@ class WarpInManager(Manager, IManagerMediator):
         if not self.requested_warp_ins:
             return
 
-        own_structures_dict: dict[UnitTypeId, list[Unit]] = (
-            self.manager_mediator.get_own_structures_dict
-        )
+        own_structures_dict: dict[
+            UnitTypeId, list[Unit]
+        ] = self.manager_mediator.get_own_structures_dict
         pylons: list[Unit] = [
             s for s in own_structures_dict[UnitTypeId.PYLON] if s.is_ready
         ]

--- a/tests/behaviors/combat/group/test_stutter_group_back.py
+++ b/tests/behaviors/combat/group/test_stutter_group_back.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/group/test_stutter_group_back.py
+++ b/tests/behaviors/combat/group/test_stutter_group_back.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_a_move.py
+++ b/tests/behaviors/combat/individual/test_a_move.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_a_move.py
+++ b/tests/behaviors/combat/individual/test_a_move.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_attack_target.py
+++ b/tests/behaviors/combat/individual/test_attack_target.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_attack_target.py
+++ b/tests/behaviors/combat/individual/test_attack_target.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_keep_unit_safe.py
+++ b/tests/behaviors/combat/individual/test_keep_unit_safe.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/combat/individual/test_keep_unit_safe.py
+++ b/tests/behaviors/combat/individual/test_keep_unit_safe.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/combat/individual/test_shoot_target_in_range.py
+++ b/tests/behaviors/combat/individual/test_shoot_target_in_range.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_shoot_target_in_range.py
+++ b/tests/behaviors/combat/individual/test_shoot_target_in_range.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/test_combat_maneuver.py
+++ b/tests/behaviors/combat/test_combat_maneuver.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/combat/test_combat_maneuver.py
+++ b/tests/behaviors/combat/test_combat_maneuver.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/macro/test_auto_supply.py
+++ b/tests/behaviors/macro/test_auto_supply.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/macro/test_auto_supply.py
+++ b/tests/behaviors/macro/test_auto_supply.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 from os.path import abspath, dirname, join

--- a/tests/generate_pickle_data.py
+++ b/tests/generate_pickle_data.py
@@ -5,6 +5,7 @@ TODO: Make this pickle `ares` specific stuff (manager hub?) so we can run tests.
 """
 
 from __future__ import annotations
+
 import lzma
 import os
 import pickle

--- a/tests/generate_pickle_data.py
+++ b/tests/generate_pickle_data.py
@@ -4,6 +4,7 @@ Thanks to burny's `python-sc2` where most of this logic was taken from.
 TODO: Make this pickle `ares` specific stuff (manager hub?) so we can run tests.
 """
 
+from __future__ import annotations
 import lzma
 import os
 import pickle

--- a/tests/generate_pickle_data.py
+++ b/tests/generate_pickle_data.py
@@ -9,7 +9,6 @@ import os
 import pickle
 import sys
 from os.path import abspath, dirname
-from typing import Optional
 
 from loguru import logger
 from s2clientprotocol import sc2api_pb2 as sc_pb
@@ -29,7 +28,7 @@ from ares.dicts.unit_tech_requirement import UNIT_TECH_REQUIREMENT
 
 
 class ExporterBot(AresBot):
-    def __init__(self, game_step_override: Optional[int] = None):
+    def __init__(self, game_step_override: int | None = None):
         super().__init__(game_step_override)
         self.map_name: str = None
 

--- a/tests/load_bot_from_pickle.py
+++ b/tests/load_bot_from_pickle.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 import importlib
 import lzma

--- a/tests/load_bot_from_pickle.py
+++ b/tests/load_bot_from_pickle.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 import importlib
 import lzma

--- a/tests/managers/test_ability_tracker_manager.py
+++ b/tests/managers/test_ability_tracker_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_ability_tracker_manager.py
+++ b/tests/managers/test_ability_tracker_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest
@@ -36,9 +37,9 @@ class TestAbilityTrackerManager:
             unit_tag=unit_tag,
         )
         # assert
-        unit_to_ability_dict: dict[int, dict[AbilityId, int]] = (
-            ability_tracker_manager.unit_to_ability_dict
-        )
+        unit_to_ability_dict: dict[
+            int, dict[AbilityId, int]
+        ] = ability_tracker_manager.unit_to_ability_dict
 
         # unit present in ability tracker
         assert unit_tag in unit_to_ability_dict

--- a/tests/managers/test_building_manager.py
+++ b/tests/managers/test_building_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_building_manager.py
+++ b/tests/managers/test_building_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_data_manager.py
+++ b/tests/managers/test_data_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_data_manager.py
+++ b/tests/managers/test_data_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_grid_manager.py
+++ b/tests/managers/test_grid_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/managers/test_grid_manager.py
+++ b/tests/managers/test_grid_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import numpy as np

--- a/tests/managers/test_intel_manager.py
+++ b/tests/managers/test_intel_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_intel_manager.py
+++ b/tests/managers/test_intel_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_placement_manager.py
+++ b/tests/managers/test_placement_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_placement_manager.py
+++ b/tests/managers/test_placement_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest
@@ -26,9 +27,9 @@ class TestPlacementManager:
         """
         placement_manager: PlacementManager = bot.manager_hub.placement_manager
         if len(bot.expansion_locations_list) >= 2:
-            placements_dict: dict[Point2, dict[BuildingSize, dict]] = (
-                placement_manager.placements_dict
-            )
+            placements_dict: dict[
+                Point2, dict[BuildingSize, dict]
+            ] = placement_manager.placements_dict
             for el, placements in placements_dict.items():
                 assert len(placements[BuildingSize.TWO_BY_TWO]) >= 1
                 assert len(placements[BuildingSize.THREE_BY_THREE]) >= 0
@@ -39,9 +40,9 @@ class TestPlacementManager:
         """
         placement_manager: PlacementManager = bot.manager_hub.placement_manager
         if len(bot.expansion_locations_list) >= 2:
-            placements_dict: dict[Point2, dict[BuildingSize, dict]] = (
-                placement_manager.placements_dict
-            )
+            placements_dict: dict[
+                Point2, dict[BuildingSize, dict]
+            ] = placement_manager.placements_dict
             for el, placements in placements_dict.items():
                 if el == bot.start_location:
                     assert len(placements[BuildingSize.THREE_BY_THREE]) >= 13

--- a/tests/managers/test_resource_manager.py
+++ b/tests/managers/test_resource_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_resource_manager.py
+++ b/tests/managers/test_resource_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_unit_role_manager.py
+++ b/tests/managers/test_unit_role_manager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_unit_role_manager.py
+++ b/tests/managers/test_unit_role_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/mock_build_order.py
+++ b/tests/mock_build_order.py
@@ -1,5 +1,7 @@
 # this is how ares would read if from the yml file
 # PLEASE DON'T EDIT THIS!
+from __future__ import annotations
+
 MOCK_BUILD_ORDER: list[str] = [
     "14 supply @ ramp",
     "16 barracks @ ramp",

--- a/tests/mock_config.py
+++ b/tests/mock_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 MOCK_CONFIG: dict = {
     "UseData": False,
     "Debug": False,

--- a/tests/test_bots/melee_bot.py
+++ b/tests/test_bots/melee_bot.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_bots/melee_bot.py
+++ b/tests/test_bots/melee_bot.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_bots/micro_bot.py
+++ b/tests/test_bots/micro_bot.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_bots/micro_bot.py
+++ b/tests/test_bots/micro_bot.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -2,6 +2,7 @@
 TODO: Work out how to test the build runner properly
 """
 
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -3,6 +3,7 @@ TODO: Work out how to test the build runner properly
 """
 
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_custom_bot_ai.py
+++ b/tests/test_custom_bot_ai.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest

--- a/tests/test_custom_bot_ai.py
+++ b/tests/test_custom_bot_ai.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_manager_mediator.py
+++ b/tests/test_manager_mediator.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_manager_mediator.py
+++ b/tests/test_manager_mediator.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 import pytest
@@ -35,9 +36,9 @@ class TestMediator:
             unit_tag=unit_tag,
         )
         # assert
-        unit_to_ability_dict: dict[int, dict[AbilityId, int]] = (
-            bot.mediator.get_unit_to_ability_dict
-        )
+        unit_to_ability_dict: dict[
+            int, dict[AbilityId, int]
+        ] = bot.mediator.get_unit_to_ability_dict
 
         # unit present in ability tracker
         assert unit_tag in unit_to_ability_dict
@@ -56,9 +57,9 @@ class TestMediator:
             unit_tag=unit_tag,
         )
         # assert
-        unit_to_ability_dict: dict[int, dict[AbilityId, int]] = (
-            bot.mediator.get_unit_to_ability_dict
-        )
+        unit_to_ability_dict: dict[
+            int, dict[AbilityId, int]
+        ] = bot.mediator.get_unit_to_ability_dict
 
         # unit present in ability tracker
         assert unit_tag in unit_to_ability_dict

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,7 @@ Starts as a random race and speed mines with 12 workers.
 
 """
 
+from __future__ import annotations
 import random
 import sys
 from os import path

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,7 +10,6 @@ import sys
 from os import path
 from os.path import abspath, dirname
 from pathlib import Path
-from typing import List
 
 import yaml
 
@@ -64,13 +63,13 @@ def main():
     bot1 = Bot(race, TestBot(), bot_name)
 
     # Local game
-    map_list: List[str] = [
+    map_list: list[str] = [
         p.name.replace(f".{MAP_FILE_EXT}", "")
         for p in Path(MAPS_PATH).glob(f"*.{MAP_FILE_EXT}")
         if p.is_file()
     ]
     # alternative example code if finding the map path is problematic
-    # map_list: List[str] = [
+    # map_list: list[str] = [
     #     "BerlingradAIE",
     #     "InsideAndOutAIE",
     #     "MoondanceAIE",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,6 +6,7 @@ Starts as a random race and speed mines with 12 workers.
 """
 
 from __future__ import annotations
+
 import random
 import sys
 from os import path

--- a/tests/travis_test_script.py
+++ b/tests/travis_test_script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 import time


### PR DESCRIPTION
Refactor: Enable deferred type evaluation (from __future__ import annotations)

Benefits:

- Allows clean (no "" needed) TYPE_CHECKING imports.

- Faster bot initialization. (minor benefit)

- Lower RAM footprint in game by storing type hints strings rather than objects. (minor benefit)

- Import itself generates no overhead, more like a switch/bool. As far as I can tell, there shouldn't be any issue putting it on every file.

Risks:

- Issues if get_type_hints(), eval(), Pydantic/dataclasses are used, but we don't seem to.