### PR TITLE
refactor(clean): deferred type evaluation enable

### DIFF
--- a/docs/tutorials/custom_behaviors.md
+++ b/docs/tutorials/custom_behaviors.md
@@ -55,7 +55,7 @@ As long as our behavior class follows the `CombatIndividualBehavior` Protocol, w
 our existing `offensive_attack` `CombatManeuver`. 
 - `CombatIndividualBehavior` Protocol says we should implement an `execute` method with the following signature:
 
-`def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:`
+`def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:`
 
 Notice this method should return a `booleon`, this should return `True` if this implemented
 `CombatIndividualBehavior` carried out an action, and `False` otherwise.
@@ -65,6 +65,8 @@ With this is mind let's implement a `SiegeTankDecision` custom behavior, you cou
 
 ```python
 # siege_tank_decision.py`
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -93,7 +95,7 @@ class SiegeTankDecision(CombatIndividualBehavior):
 
     unit: Unit
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         unit_pos: Point2 = self.unit.position
         type_id: UnitTypeId = self.unit.type_id
         

--- a/sc2_helper/combat_simulator.py
+++ b/sc2_helper/combat_simulator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .sc2_helper import CombatPredictor, CombatSettings
 
 

--- a/sc2_helper/helper_functions.py
+++ b/sc2_helper/helper_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .sc2_helper import circles_intersect as r_circles_intersect
 from .sc2_helper import find_points_inside_circle as r_find_points_inside_circle
 

--- a/sc2_helper/test.py
+++ b/sc2_helper/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from time import perf_counter_ns
 
 from sc2 import BotAI, Difficulty, Race, UnitTypeId, maps, run_game

--- a/src/ares/behavior_exectioner.py
+++ b/src/ares/behavior_exectioner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ares.behaviors.behavior import Behavior
@@ -25,9 +27,9 @@ class BehaviorExecutioner:
 
     """
 
-    def __init__(self, ai: "AresBot", config: dict, mediator: ManagerMediator):
+    def __init__(self, ai: AresBot, config: dict, mediator: ManagerMediator):
         """Inits BehaviorExecutioner class."""
-        self.ai: "AresBot" = ai
+        self.ai: AresBot = ai
         self.config: dict = config
         self.mediator: ManagerMediator = mediator
         self.behaviors: list = []

--- a/src/ares/behaviors/behavior.py
+++ b/src/ares/behaviors/behavior.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.managers.manager_mediator import ManagerMediator
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
 class Behavior(Protocol):
     """Interface that all behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Parameters:
@@ -20,6 +22,5 @@ class Behavior(Protocol):
         Returns:
             bool: Return value depends on combat/macros behavior interfaces.
             See those interfaces for more info.
-
         """
         ...

--- a/src/ares/behaviors/combat/combat_behavior.py
+++ b/src/ares/behaviors/combat/combat_behavior.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 class CombatBehavior(Behavior, Protocol):
     """Interface that all combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.

--- a/src/ares/behaviors/combat/combat_maneuver.py
+++ b/src/ares/behaviors/combat/combat_maneuver.py
@@ -96,7 +96,7 @@ class CombatManeuver(Behavior):
         """
         self.micros.append(behavior)
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for order in self.micros:
             if order.execute(ai, config, mediator):
                 # executed an action

--- a/src/ares/behaviors/combat/group/a_move_group.py
+++ b/src/ares/behaviors/combat/group/a_move_group.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -34,7 +36,7 @@ class AMoveGroup(CombatGroupBehavior):
     group_tags: set[int]
     target: Point2 | Unit
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/group/combat_group_behavior.py
+++ b/src/ares/behaviors/combat/group/combat_group_behavior.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from cython_extensions import cy_distance_to_squared
@@ -15,7 +17,7 @@ if TYPE_CHECKING:
 class CombatGroupBehavior(Behavior, Protocol):
     """Interface that all group combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Parameters:

--- a/src/ares/behaviors/combat/group/group_use_ability.py
+++ b/src/ares/behaviors/combat/group/group_use_ability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -45,7 +47,7 @@ class GroupUseAbility(CombatGroupBehavior):
     target: Point2 | Unit | None
     sync_command: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
         issue_command: bool

--- a/src/ares/behaviors/combat/group/keep_group_safe.py
+++ b/src/ares/behaviors/combat/group/keep_group_safe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +40,7 @@ class KeepGroupSafe(CombatGroupBehavior):
     grid: np.ndarray
     attack_in_range_enemy: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/group/path_group_to_target.py
+++ b/src/ares/behaviors/combat/group/path_group_to_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -71,7 +73,7 @@ class PathGroupToTarget(CombatGroupBehavior):
     danger_threshold: float = 5.0
     prevent_duplicate: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert isinstance(
             self.start, Point2
         ), f"{self.start} should be `Point2`, got {type(self.start)}"

--- a/src/ares/behaviors/combat/group/stutter_group_back.py
+++ b/src/ares/behaviors/combat/group/stutter_group_back.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -46,7 +48,7 @@ class StutterGroupBack(CombatGroupBehavior):
     target: Point2 | Unit
     grid: np.ndarray
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 
@@ -96,7 +98,7 @@ class StutterGroupBack(CombatGroupBehavior):
 
         return True
 
-    def _calculate_retreat_position(self, ai: "AresBot") -> Point2:
+    def _calculate_retreat_position(self, ai: AresBot) -> Point2:
         """Search 8 directions for somewhere to retreat to."""
         distance = len(self.group) * 1.5
 

--- a/src/ares/behaviors/combat/group/stutter_group_forward.py
+++ b/src/ares/behaviors/combat/group/stutter_group_forward.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,7 +35,7 @@ class StutterGroupForward(CombatGroupBehavior):
     target: Point2 | Unit
     enemies: list[Unit] | Units
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if len(self.group) == 0:
             return False
 

--- a/src/ares/behaviors/combat/individual/a_move.py
+++ b/src/ares/behaviors/combat/individual/a_move.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -37,7 +39,7 @@ class AMove(CombatIndividualBehavior):
     target: Point2 | Unit
     success_at_distance: float = 7.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             self.success_at_distance > 0
             and cy_distance_to(self.unit.position, self.target.position)

--- a/src/ares/behaviors/combat/individual/attack_target.py
+++ b/src/ares/behaviors/combat/individual/attack_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,7 +38,7 @@ class AttackTarget(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         self.unit.attack(self.target)
         return True

--- a/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/auto_use_aoe_ability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -45,7 +47,7 @@ class AutoUseAOEAbility(CombatIndividualBehavior):
     recalculate: bool = False
     stack_same_spell: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         _abilities: set[AbilityId] = self.unit.abilities
         for ability in AOE_ABILITY_SPELLS_INFO:
             if ability not in _abilities:

--- a/src/ares/behaviors/combat/individual/combat_individual_behavior.py
+++ b/src/ares/behaviors/combat/individual/combat_individual_behavior.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 class CombatIndividualBehavior(Behavior, Protocol):
     """Interface that all combat behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.

--- a/src/ares/behaviors/combat/individual/drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/drop_cargo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +40,7 @@ class DropCargo(CombatIndividualBehavior):
     unit: Unit
     target: Point2
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # TODO: Expand logic as needed, initial working version.
         # no action executed
         if self.unit.cargo_used == 0 or not cy_in_pathing_grid_ma(

--- a/src/ares/behaviors/combat/individual/ghost_snipe.py
+++ b/src/ares/behaviors/combat/individual/ghost_snipe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -30,7 +32,7 @@ class GhostSnipe(CombatIndividualBehavior):
     unit: Unit
     close_enemy: list[Unit] | Units
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             ai.enemy_race != Race.Zerg
             or not self.close_enemy
@@ -48,7 +50,7 @@ class GhostSnipe(CombatIndividualBehavior):
         return False
 
     def get_snipe_target(
-        self, ai: "AresBot", ghosts: list[Unit], units: Units
+        self, ai: AresBot, ghosts: list[Unit], units: Units
     ) -> Unit | None:
         max_value: float = 0.0
         target: Unit | None = None

--- a/src/ares/behaviors/combat/individual/keep_unit_safe.py
+++ b/src/ares/behaviors/combat/individual/keep_unit_safe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +40,7 @@ class KeepUnitSafe(CombatIndividualBehavior):
     unit: Unit
     grid: np.ndarray
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no action executed
         if mediator.is_position_safe(grid=self.grid, position=self.unit.position):
             return False

--- a/src/ares/behaviors/combat/individual/medivac_heal.py
+++ b/src/ares/behaviors/combat/individual/medivac_heal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -31,7 +33,7 @@ class MedivacHeal(CombatIndividualBehavior):
     grid: np.ndarray
     keep_safe: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.unit.type_id != UnitTypeId.MEDIVAC:
             return False
 

--- a/src/ares/behaviors/combat/individual/move_to_safe_target.py
+++ b/src/ares/behaviors/combat/individual/move_to_safe_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -66,7 +68,7 @@ class MoveToSafeTarget(CombatIndividualBehavior):
     danger_threshold: float = 5.0
     radius: float = 12.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if cy_distance_to(self.unit.position, self.target) <= self.success_at_distance:
             return False
 

--- a/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/nydus_path_unit_to_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -51,7 +53,7 @@ class NydusPathUnitToTarget(CombatIndividualBehavior):
     smoothing: bool = False
     exit_nydus_max_influence: float = 10.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         distance_to_target: float = cy_distance_to(self.unit.position, self.target)
         # no action executed
         if distance_to_target < self.success_at_distance:

--- a/src/ares/behaviors/combat/individual/path_unit_to_target.py
+++ b/src/ares/behaviors/combat/individual/path_unit_to_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,7 +58,7 @@ class PathUnitToTarget(CombatIndividualBehavior):
     danger_distance: float = 20.0
     danger_threshold: float = 5.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         distance_to_target: float = cy_distance_to(self.unit.position, self.target)
         # no action executed
         if distance_to_target < self.success_at_distance:

--- a/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_and_drop_cargo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -61,7 +63,7 @@ class PickUpAndDropCargo(CombatIndividualBehavior):
     keep_dropship_safe: bool = True
     success_at_distance: float = 2.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # check for units to pick up.
         if PickUpCargo(
             unit=self.unit,

--- a/src/ares/behaviors/combat/individual/pick_up_cargo.py
+++ b/src/ares/behaviors/combat/individual/pick_up_cargo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -49,7 +51,7 @@ class PickUpCargo(CombatIndividualBehavior):
     pickup_targets: list[Unit] | Units
     cargo_switch_to_role: UnitRole | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no action executed
         if not self.pickup_targets or self.unit.type_id not in PICKUP_RANGE:
             # just ensure tags inside are assigned correctly

--- a/src/ares/behaviors/combat/individual/place_predictive_aoe.py
+++ b/src/ares/behaviors/combat/individual/place_predictive_aoe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -43,7 +45,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
     reaper_grenade_range: float = 5.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.aoe_ability in self.unit.abilities:
             # try to fire the ability if we find a position
@@ -55,7 +57,7 @@ class PlacePredictiveAoE(CombatIndividualBehavior):
         # no position found or the ability isn't ready
         return False
 
-    def _calculate_target_position(self, ai: "AresBot") -> Point2:
+    def _calculate_target_position(self, ai: AresBot) -> Point2:
         """Calculate where we want to put the AoE.
 
         Returns

--- a/src/ares/behaviors/combat/individual/queen_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/queen_spread_creep.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -41,7 +43,7 @@ class QueenSpreadCreep(CombatIndividualBehavior):
     cancel_if_close_enemy: bool = True
     pre_move_queen_to_tumor: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         spreading: bool = self.unit.is_using_ability(AbilityId.BUILD_CREEPTUMOR)
 
         grid: np.ndarray = mediator.get_ground_grid

--- a/src/ares/behaviors/combat/individual/raven_auto_turret.py
+++ b/src/ares/behaviors/combat/individual/raven_auto_turret.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -27,7 +29,7 @@ class RavenAutoTurret(CombatIndividualBehavior):
     unit: Unit
     all_close_enemy: list[Unit]
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if AbilityId.BUILDAUTOTURRET_AUTOTURRET not in self.unit.abilities:
             return False
 

--- a/src/ares/behaviors/combat/individual/reaper_grenade.py
+++ b/src/ares/behaviors/combat/individual/reaper_grenade.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,7 +58,7 @@ class ReaperGrenade(CombatIndividualBehavior):
     place_predictive: bool = True
     reaper_grenade_range: float = 5.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if (
             not self.enemy_units
             or AbilityId.KD8CHARGE_KD8CHARGE not in self.unit.abilities

--- a/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
+++ b/src/ares/behaviors/combat/individual/shoot_and_move_to_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -55,7 +57,7 @@ class ShootAndMoveToTarget(CombatIndividualBehavior):
     dist_to_target: float = 4.0
     attack_destructables: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if ShootTargetInRange(self.unit, self.enemy_units).execute(
             ai, config, mediator
         ):

--- a/src/ares/behaviors/combat/individual/shoot_target_in_range.py
+++ b/src/ares/behaviors/combat/individual/shoot_target_in_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +45,7 @@ class ShootTargetInRange(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if not self.targets:
             return False

--- a/src/ares/behaviors/combat/individual/siege_tank_decision.py
+++ b/src/ares/behaviors/combat/individual/siege_tank_decision.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -52,7 +54,7 @@ class SiegeTankDecision(CombatIndividualBehavior):
     remain_sieged: bool = False
     force_unsiege: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         type_id: UnitTypeId = self.unit.type_id
         if type_id not in TANK_TYPES:
             return False

--- a/src/ares/behaviors/combat/individual/stutter_unit_back.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_back.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +45,7 @@ class StutterUnitBack(CombatIndividualBehavior):
     grid: np.ndarray | None = None
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/combat/individual/stutter_unit_forward.py
+++ b/src/ares/behaviors/combat/individual/stutter_unit_forward.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,7 +38,7 @@ class StutterUnitForward(CombatIndividualBehavior):
     target: Unit
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/combat/individual/tumor_spread_creep.py
+++ b/src/ares/behaviors/combat/individual/tumor_spread_creep.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -43,7 +45,7 @@ class TumorSpreadCreep(CombatIndividualBehavior):
     unit: Unit
     target: Point2
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if AbilityId.BUILD_CREEPTUMOR_TUMOR not in self.unit.abilities:
             return False
 

--- a/src/ares/behaviors/combat/individual/use_ability.py
+++ b/src/ares/behaviors/combat/individual/use_ability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -44,7 +46,7 @@ class UseAbility(CombatIndividualBehavior):
     target: Point2 | Unit | None = None
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.ability not in self.unit.abilities:
             return False

--- a/src/ares/behaviors/combat/individual/use_aoe_ability.py
+++ b/src/ares/behaviors/combat/individual/use_aoe_ability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -63,7 +65,7 @@ class UseAOEAbility(CombatIndividualBehavior):
     recalculate: bool = False
     stack_same_spell: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.ability_id not in AOE_ABILITY_SPELLS_INFO:
             logger.warning(
                 f"You're trying to use {self.ability_id} with `UseAOEAbility`, "
@@ -112,7 +114,7 @@ class UseAOEAbility(CombatIndividualBehavior):
         return False
 
     def _can_cast(
-        self, ai: "AresBot", mediator: ManagerMediator, position: Point2, radius: float
+        self, ai: AresBot, mediator: ManagerMediator, position: Point2, radius: float
     ) -> bool:
         can_cast: bool = (
             len(cy_closer_than(self.targets, radius, position)) >= self.min_targets

--- a/src/ares/behaviors/combat/individual/use_transfuse.py
+++ b/src/ares/behaviors/combat/individual/use_transfuse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -33,7 +35,7 @@ class UseTransfuse(CombatIndividualBehavior):
     extra_range: float = 0.0
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         if self.unit.is_using_ability(AbilityId.TRANSFUSION_TRANSFUSION):
             return True

--- a/src/ares/behaviors/combat/individual/worker_kite_back.py
+++ b/src/ares/behaviors/combat/individual/worker_kite_back.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -55,7 +57,7 @@ class WorkerKiteBack(CombatIndividualBehavior):
     should_attack: bool = True
 
     def execute(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator, **kwargs
+        self, ai: AresBot, config: dict, mediator: ManagerMediator, **kwargs
     ) -> bool:
         unit = self.unit
         target = self.target

--- a/src/ares/behaviors/macro/addon_swap.py
+++ b/src/ares/behaviors/macro/addon_swap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -50,7 +52,7 @@ class AddonSwap(MacroBehavior):
     addon_required: UnitTypeId
     precise_addon_structure_id: UnitTypeId | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert ai.race == Race.Terran, "Can only swap addons with Terran."
         # check if user provided a precise addon into addon_required
         if self.addon_required not in ADDON_TYPES:

--- a/src/ares/behaviors/macro/auto_supply.py
+++ b/src/ares/behaviors/macro/auto_supply.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -41,7 +43,7 @@ class AutoSupply(MacroBehavior):
     return_true_if_supply_required: bool = True
     closest_to: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self._num_supply_required(ai, mediator) > 0:
             supply_type: UnitTypeId = RACE_SUPPLY[ai.race]
             if ai.race == Race.Zerg:
@@ -58,7 +60,7 @@ class AutoSupply(MacroBehavior):
         return False
 
     @staticmethod
-    def _num_supply_required(ai: "AresBot", mediator: ManagerMediator) -> int:
+    def _num_supply_required(ai: AresBot, mediator: ManagerMediator) -> int:
         """
         TODO: Improve on this initial version
             Should calculate based on townhalls for Zerg only?

--- a/src/ares/behaviors/macro/build_structure.py
+++ b/src/ares/behaviors/macro/build_structure.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -95,7 +97,7 @@ class BuildStructure(MacroBehavior):
     reaper_wall: bool = False
     find_alternative: bool = True
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if self.structure_id not in STRUCTURE_TO_BUILDING_SIZE:
             logger.error(
                 f"Invalid structure type passed to `BuildStructure`: "
@@ -161,7 +163,7 @@ class BuildStructure(MacroBehavior):
                 return True
         return False
 
-    def _enough_existing(self, ai: "AresBot", mediator: ManagerMediator) -> bool:
+    def _enough_existing(self, ai: AresBot, mediator: ManagerMediator) -> bool:
         existing_structures = mediator.get_own_structures_dict[self.structure_id]
         num_existing: int = len(
             [s for s in existing_structures if s.is_ready]
@@ -171,7 +173,7 @@ class BuildStructure(MacroBehavior):
     def _enough_existing_at_this_base(self, mediator: ManagerMediator) -> bool:
         placement_dict: dict = mediator.get_placements_dict
         size: BuildingSize = STRUCTURE_TO_BUILDING_SIZE[self.structure_id]
-        potential_placements: dict[Point2:dict] = placement_dict[self.base_location][
+        potential_placements: dict[Point2, dict] = placement_dict[self.base_location][
             size
         ]
         taken: list[Point2] = [

--- a/src/ares/behaviors/macro/build_workers.py
+++ b/src/ares/behaviors/macro/build_workers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -32,7 +34,7 @@ class BuildWorkers(MacroBehavior):
 
     to_count: int
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         worker_type: UnitTypeId = ai.worker_type
         if (
             ai.can_afford(worker_type)

--- a/src/ares/behaviors/macro/expansion_controller.py
+++ b/src/ares/behaviors/macro/expansion_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -42,7 +44,7 @@ class ExpansionController(MacroBehavior):
     max_pending: int = 1
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # already have enough / or enough pending
         if (
             len([th for th in ai.townhalls if th.is_ready])
@@ -67,7 +69,7 @@ class ExpansionController(MacroBehavior):
         return False
 
     def _get_next_expansion_location(
-        self, ai: "AresBot", mediator: ManagerMediator
+        self, ai: AresBot, mediator: ManagerMediator
     ) -> Point2 | None:
         grid: np.ndarray = mediator.get_ground_grid
         for el in mediator.get_own_expansions:

--- a/src/ares/behaviors/macro/gas_building_controller.py
+++ b/src/ares/behaviors/macro/gas_building_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -8,6 +10,7 @@ from sc2.units import Units
 
 if TYPE_CHECKING:
     from ares import AresBot
+
 from ares.behaviors.macro.macro_behavior import MacroBehavior
 from ares.managers.manager_mediator import ManagerMediator
 
@@ -41,7 +44,7 @@ class GasBuildingController(MacroBehavior):
     max_pending: int = 1
     closest_to: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         num_gas: int
         if ai.race == Race.Terran:
             num_gas = ai.not_started_but_in_building_tracker(ai.gas_type) + len(

--- a/src/ares/behaviors/macro/macro_behavior.py
+++ b/src/ares/behaviors/macro/macro_behavior.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 from ares.behaviors.behavior import Behavior
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 class MacroBehavior(Behavior, Protocol):
     """Interface that all macro behaviors should adhere to."""
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         """Execute the implemented behavior.
 
         Compared to CombatBehavior a MacroBehavior may be a larger isolated task.

--- a/src/ares/behaviors/macro/macro_plan.py
+++ b/src/ares/behaviors/macro/macro_plan.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -45,7 +47,7 @@ class MacroPlan(Behavior):
     def add(self, behavior: MacroBehavior) -> None:
         self.macros.append(behavior)
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for macro in self.macros:
             if macro.execute(ai, config, mediator):
                 # executed a macro behavior

--- a/src/ares/behaviors/macro/mining.py
+++ b/src/ares/behaviors/macro/mining.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable
 
@@ -82,7 +84,7 @@ class Mining(MacroBehavior):
     locked_action_tags: dict[int, float] = field(default_factory=dict)
     weight_safety_limit: float = 12.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         workers: Units = mediator.get_units_from_role(
             role=UnitRole.GATHERING,
             unit_type=ai.worker_type,
@@ -256,7 +258,7 @@ class Mining(MacroBehavior):
             mediator.find_closest_safe_spot(from_pos=worker.position, grid=grid)
         )
 
-    def _do_standard_mining(self, ai: "AresBot", worker: Unit, resource: Unit) -> None:
+    def _do_standard_mining(self, ai: AresBot, worker: Unit, resource: Unit) -> None:
         worker_tag: int = worker.tag
         # prevent spam clicking workers on patch to reduce APM
         if worker_tag in self.locked_action_tags:
@@ -297,7 +299,7 @@ class Mining(MacroBehavior):
 
     def _long_distance_mining(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         mediator: ManagerMediator,
         grid: np.ndarray,
         worker: Unit,
@@ -428,7 +430,7 @@ class Mining(MacroBehavior):
         Gather command and letting the SC2 engine manage the worker.
 
         Parameters:
-            ai: Main AresBot object
+            ai: AresBot
             distance_to_townhall_factor: Multiplier used for finding the target
                 of the Move command when returning resources.
             target: Mineral field or Townhall that the worker should be
@@ -479,12 +481,12 @@ class Mining(MacroBehavior):
 
     @staticmethod
     def _safe_long_distance_mineral_fields(
-        ai: "AresBot", mediator: ManagerMediator
+        ai: AresBot, mediator: ManagerMediator
     ) -> list[Unit]:
         """Find mineral fields for long distance miners.
 
         Parameters:
-            ai: Main AresBot object
+            ai: AresBot
             mediator: Manager mediator to interact with the managers
 
         Returns:
@@ -511,7 +513,7 @@ class Mining(MacroBehavior):
 
     @staticmethod
     def _worker_attacking_enemy(
-        ai: "AresBot", dist_to_resource: float, worker: Unit
+        ai: AresBot, dist_to_resource: float, worker: Unit
     ) -> bool:
         if not worker.is_collecting or dist_to_resource > 1.0:
             if enemies := cy_in_attack_range(worker, ai.enemy_units):

--- a/src/ares/behaviors/macro/production_controller.py
+++ b/src/ares/behaviors/macro/production_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -81,7 +83,7 @@ class ProductionController(MacroBehavior):
     should_repower_structures: bool = True
     max_production_structures: int = 12
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # no need for anything else if zerg
         if ai.race == Race.Zerg:
             logger.warning(
@@ -231,7 +233,7 @@ class ProductionController(MacroBehavior):
 
     def _building_production_due_to_bank(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         unit_type_id: UnitTypeId,
         collection_rate_minerals: int,
         collection_rate_vespene: int,
@@ -285,7 +287,7 @@ class ProductionController(MacroBehavior):
         return False
 
     def is_flying_production(
-        self, ai: "AresBot", flying_structures: dict, train_from: set[UnitTypeId]
+        self, ai: AresBot, flying_structures: dict, train_from: set[UnitTypeId]
     ) -> bool:
         if ai.race == Race.Terran:
             prod_flying: bool = False
@@ -307,7 +309,7 @@ class ProductionController(MacroBehavior):
         return False
 
     def _add_techlab_to_existing(
-        self, ai: "AresBot", unit_type_id: UnitTypeId, researched_from_id
+        self, ai: AresBot, unit_type_id: UnitTypeId, researched_from_id
     ) -> bool:
         structures_dict: dict = ai.mediator.get_own_structures_dict
         build_techlab_from: UnitTypeId = BUILD_TECHLAB_FROM[researched_from_id]

--- a/src/ares/behaviors/macro/protoss_static_defence.py
+++ b/src/ares/behaviors/macro/protoss_static_defence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -46,7 +48,7 @@ class ProtossStaticDefence(MacroBehavior):
     max_on_route: int = 1
     tech_base_location: Point2 | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if ai.race != Race.Protoss:
             logger.warning(
                 f"{ai.time_formatted}: ProtossStaticDefence only supports Protoss."
@@ -123,7 +125,7 @@ class ProtossStaticDefence(MacroBehavior):
         return False
 
     def _tech_required(
-        self, ai: "AresBot", config: dict, mediator: ManagerMediator
+        self, ai: AresBot, config: dict, mediator: ManagerMediator
     ) -> bool:
         tech_location: Point2 = self.tech_base_location or ai.start_location
 

--- a/src/ares/behaviors/macro/restore_power.py
+++ b/src/ares/behaviors/macro/restore_power.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -38,7 +40,7 @@ class RestorePower(MacroBehavior):
     ```
     """
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if structures_no_power := [
             s
             for s in ai.structures
@@ -89,7 +91,7 @@ class RestorePower(MacroBehavior):
 
     @staticmethod
     def _restoring_power(
-        structure: Unit, ai: "AresBot", config: dict, mediator: ManagerMediator
+        structure: Unit, ai: AresBot, config: dict, mediator: ManagerMediator
     ) -> bool:
         """Given an unpowered structure, find a pylon position.
 

--- a/src/ares/behaviors/macro/spawn_controller.py
+++ b/src/ares/behaviors/macro/spawn_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from math import isclose
 from typing import TYPE_CHECKING
@@ -77,7 +79,7 @@ class SpawnController(MacroBehavior):
     __excluded_structure_tags: set[int] = field(default_factory=set)
     __supply_available: float = 0.0
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         # allow gateways to morph before issuing commands
         if UpgradeId.WARPGATERESEARCH in ai.state.upgrades and [
             g
@@ -235,7 +237,7 @@ class SpawnController(MacroBehavior):
 
     def _add_to_build_dict(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         type_id: UnitTypeId,
         base_unit: list[Unit],
         amount: int,
@@ -270,7 +272,7 @@ class SpawnController(MacroBehavior):
 
     @staticmethod
     def _calculate_build_amount(
-        ai: "AresBot",
+        ai: AresBot,
         unit_type: UnitTypeId,
         base_units: list[Unit],
         supply_left: float,
@@ -305,14 +307,14 @@ class SpawnController(MacroBehavior):
         return amount, supply_cost, cost
 
     @staticmethod
-    def _can_afford(ai: "AresBot", unit_type_id: UnitTypeId) -> bool:
+    def _can_afford(ai: AresBot, unit_type_id: UnitTypeId) -> bool:
         if unit_type_id == UnitTypeId.ARCHON:
             return True
         return ai.can_afford(unit_type_id)
 
     @staticmethod
     def _handle_archon_morph(
-        ai: "AresBot", build_structures: list[Unit], mediator: ManagerMediator
+        ai: AresBot, build_structures: list[Unit], mediator: ManagerMediator
     ) -> None:
         unit_role_dict: dict[UnitRole, set] = mediator.get_unit_role_dict
         build_structures = [
@@ -326,7 +328,7 @@ class SpawnController(MacroBehavior):
         templar: list[Unit] = build_structures[:2]
         ai.request_archon_morph(templar)
 
-    def _morph_units(self, ai: "AresBot", mediator: ManagerMediator) -> bool:
+    def _morph_units(self, ai: AresBot, mediator: ManagerMediator) -> bool:
         did_action: bool = False
         for unit, value in self.__build_dict.items():
             did_action = True

--- a/src/ares/behaviors/macro/speed_mining.py
+++ b/src/ares/behaviors/macro/speed_mining.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -53,7 +55,7 @@ class SpeedMining(CombatIndividualBehavior):
     distance_to_townhall_factor: float = 1.08
     townhall: Unit | None = None
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         if not ai.townhalls:
             logger.warning(
                 f"{ai.time_formatted} Attempting to speed mine with no townhalls"

--- a/src/ares/behaviors/macro/tech_up.py
+++ b/src/ares/behaviors/macro/tech_up.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,7 +20,7 @@ from ares.managers.manager_mediator import ManagerMediator
 if TYPE_CHECKING:
     from ares import AresBot
 
-BUILD_TECHLAB_FROM: dict[UnitTypeId:UnitTypeId] = {
+BUILD_TECHLAB_FROM: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.BARRACKSTECHLAB: UnitTypeId.BARRACKS,
     UnitTypeId.FACTORYTECHLAB: UnitTypeId.FACTORY,
     UnitTypeId.STARPORTTECHLAB: UnitTypeId.STARPORT,
@@ -52,7 +54,7 @@ class TechUp(MacroBehavior):
     base_location: Point2
     ignore_existing_techlabs: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         assert isinstance(
             self.desired_tech, (UpgradeId, UnitTypeId)
         ), f"Wrong type provided for `desired_tech`, got {type(self.desired_tech)}"
@@ -188,7 +190,7 @@ class TechUp(MacroBehavior):
 
     def _adding_techlab(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         base_location: Point2,
         researched_from_id: UnitTypeId,
         tech_required: list[UnitTypeId],
@@ -261,7 +263,7 @@ class TechUp(MacroBehavior):
                 return True
         return False
 
-    def _upgrade_zerg_townhall(self, structure_type: UnitTypeId, ai: "AresBot") -> bool:
+    def _upgrade_zerg_townhall(self, structure_type: UnitTypeId, ai: AresBot) -> bool:
         structures_dict = ai.mediator.get_own_structures_dict
         if (
             not ai.can_afford(structure_type)

--- a/src/ares/behaviors/macro/upgrade_ccs.py
+++ b/src/ares/behaviors/macro/upgrade_ccs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -42,7 +44,7 @@ class UpgradeCCs(MacroBehavior):
     to: UnitTypeId
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         ccs: list[Unit] = [
             th
             for th in mediator.get_own_structures_dict[UnitTypeId.COMMANDCENTER]

--- a/src/ares/behaviors/macro/upgrade_controller.py
+++ b/src/ares/behaviors/macro/upgrade_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -26,8 +28,7 @@ class UpgradeController(MacroBehavior):
     currently researchable this behavior will automatically
     make the tech buildings required.
 
-
-    Example:
+    Examples
     ```py
     from ares.behaviors.macro import UpgradeController
     from sc2.ids.upgrade_id import UpgradeId
@@ -61,7 +62,7 @@ class UpgradeController(MacroBehavior):
     auto_tech_up_enabled: bool = True
     prioritize: bool = False
 
-    def execute(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> bool:
+    def execute(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> bool:
         for upgrade in self.upgrade_list:
             if ai.pending_or_complete_upgrade(upgrade):
                 continue

--- a/src/ares/build_runner/build_order_parser.py
+++ b/src/ares/build_runner/build_order_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
@@ -43,7 +45,7 @@ class BuildOrderParser:
         parse: Parses the `raw_build_order` attribute into a list of `BuildOrderStep`.
     """
 
-    ai: "AresBot"
+    ai: AresBot
     build_order_step_dict: dict | None = None
 
     def __post_init__(self) -> None:
@@ -174,14 +176,13 @@ class BuildOrderParser:
 
     def _generate_addon_build_step(self, commands) -> Callable:
         # Non-standard attribute format to bypass PyCharm docstring completion quirks.
-        """
-        Generates a callable build step for executing an
+        """Generates a callable build step for executing an
         `AddonSwap` command in the build runner.
 
         The `AddonSwap` command allows structures to exchange addon components.
         This function validates the provided command arguments to ensure they
-        represent valid structure types
-        before creating a lambda build step for execution.
+        represent valid structure types before creating a lambda build step for
+        execution.
 
         Args:
             commands (list[str]): List of command parameters.

--- a/src/ares/build_runner/build_order_runner.py
+++ b/src/ares/build_runner/build_order_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared, cy_towards
@@ -80,7 +82,7 @@ class BuildOrderRunner:
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         chosen_opening: str,
         config: dict,
         mediator: ManagerMediator,

--- a/src/ares/build_runner/build_order_step.py
+++ b/src/ares/build_runner/build_order_step.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable
 

--- a/src/ares/cache.py
+++ b/src/ares/cache.py
@@ -1,4 +1,5 @@
 """Tools for caching attribute values."""
+from __future__ import annotations
 
 from functools import wraps
 

--- a/src/ares/chat_debug.py
+++ b/src/ares/chat_debug.py
@@ -2,6 +2,7 @@
 
 Feel free to add to this.
 """
+from __future__ import annotations
 
 from sc2.ids.unit_typeid import UnitTypeId
 from sc2.position import Point2

--- a/src/ares/config_parser.py
+++ b/src/ares/config_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from dataclasses import dataclass
 from os import path
@@ -29,7 +31,7 @@ class ConfigParser:
 
         Returns
         -------
-        Dict :
+        dict :
             Internal parsed config.yml by default, or the merged internal and
             users config files.
         """
@@ -81,7 +83,7 @@ class ConfigParser:
 
         Returns
         -------
-        Dict :
+        dict :
             A single config dictionary where user values override default values.
         """
         """Recursively merge override dictionary into default dictionary."""

--- a/src/ares/consts.py
+++ b/src/ares/consts.py
@@ -572,6 +572,15 @@ class WallOffDetection(Enum):
 
 # sets:
 
+REACTOR_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKSREACTOR,
+        UnitTypeId.FACTORYREACTOR,
+        UnitTypeId.STARPORTREACTOR,
+        UnitTypeId.REACTOR,
+    }
+)
+
 REACTOR_TRAIN_ABILITIES: list[AbilityId] = [
     AbilityId.BARRACKSTRAIN_MARINE,
     AbilityId.BARRACKSTRAIN_REAPER,
@@ -582,6 +591,15 @@ REACTOR_TRAIN_ABILITIES: list[AbilityId] = [
     AbilityId.STARPORTTRAIN_LIBERATOR,
 ]
 
+TECHLAB_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKSTECHLAB,
+        UnitTypeId.FACTORYTECHLAB,
+        UnitTypeId.STARPORTTECHLAB,
+        UnitTypeId.TECHLAB,
+    }
+)
+
 ADD_ONS: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.BARRACKSREACTOR: UnitTypeId.BARRACKS,
     UnitTypeId.FACTORYREACTOR: UnitTypeId.FACTORY,
@@ -591,193 +609,215 @@ ADD_ONS: dict[UnitTypeId, UnitTypeId] = {
     UnitTypeId.STARPORTTECHLAB: UnitTypeId.STARPORT,
 }
 
-ALL_PRODUCTION_STRUCTURES: frozenset[UnitTypeId] = {
-    UnitTypeId.BARRACKS,
-    UnitTypeId.FACTORY,
-    UnitTypeId.STARPORT,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.WARPGATE,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.STARGATE,
-}
+ALL_PRODUCTION_STRUCTURES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BARRACKS,
+        UnitTypeId.FACTORY,
+        UnitTypeId.STARPORT,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.WARPGATE,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.STARGATE,
+    }
+)
 
-ALL_STRUCTURES: frozenset[UnitTypeId] = {
-    UnitTypeId.ARMORY,
-    UnitTypeId.ASSIMILATOR,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.AUTOTURRET,
-    UnitTypeId.BANELINGNEST,
-    UnitTypeId.BARRACKS,
-    UnitTypeId.BARRACKSFLYING,
-    UnitTypeId.BARRACKSREACTOR,
-    UnitTypeId.BARRACKSTECHLAB,
-    UnitTypeId.BUNKER,
-    UnitTypeId.BYPASSARMORDRONE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CYBERNETICSCORE,
-    UnitTypeId.DARKSHRINE,
-    UnitTypeId.ELSECARO_COLONIST_HUT,
-    UnitTypeId.ENGINEERINGBAY,
-    UnitTypeId.EVOLUTIONCHAMBER,
-    UnitTypeId.EXTRACTOR,
-    UnitTypeId.EXTRACTORRICH,
-    UnitTypeId.FACTORY,
-    UnitTypeId.FACTORYFLYING,
-    UnitTypeId.FACTORYREACTOR,
-    UnitTypeId.FACTORYTECHLAB,
-    UnitTypeId.FLEETBEACON,
-    UnitTypeId.FORGE,
-    UnitTypeId.FUSIONCORE,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.GHOSTACADEMY,
-    UnitTypeId.GREATERSPIRE,
-    UnitTypeId.HATCHERY,
-    UnitTypeId.HIVE,
-    UnitTypeId.HYDRALISKDEN,
-    UnitTypeId.INFESTATIONPIT,
-    UnitTypeId.LAIR,
-    UnitTypeId.LURKERDENMP,
-    UnitTypeId.MEDIVACMENGSKACGLUESCREENDUMMY,
-    UnitTypeId.MISSILETURRET,
-    UnitTypeId.NEXUS,
-    UnitTypeId.NYDUSCANAL,
-    UnitTypeId.NYDUSCANALATTACKER,
-    UnitTypeId.NYDUSCANALCREEPER,
-    UnitTypeId.NYDUSNETWORK,
-    UnitTypeId.ORACLESTASISTRAP,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.PLANETARYFORTRESS,
-    UnitTypeId.POINTDEFENSEDRONE,
-    UnitTypeId.PYLON,
-    UnitTypeId.PYLONOVERCHARGED,
-    UnitTypeId.RAVENREPAIRDRONE,
-    UnitTypeId.REACTOR,
-    UnitTypeId.REFINERY,
-    UnitTypeId.REFINERYRICH,
-    UnitTypeId.RESOURCEBLOCKER,
-    UnitTypeId.ROACHWARREN,
-    UnitTypeId.ROBOTICSBAY,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.SENSORTOWER,
-    UnitTypeId.SHIELDBATTERY,
-    UnitTypeId.SIEGETANKMENGSKACGLUESCREENDUMMY,
-    UnitTypeId.SPAWNINGPOOL,
-    UnitTypeId.SPINECRAWLER,
-    UnitTypeId.SPINECRAWLERUPROOTED,
-    UnitTypeId.SPIRE,
-    UnitTypeId.SPORECRAWLER,
-    UnitTypeId.SPORECRAWLERUPROOTED,
-    UnitTypeId.STARGATE,
-    UnitTypeId.STARPORT,
-    UnitTypeId.STARPORTFLYING,
-    UnitTypeId.STARPORTREACTOR,
-    UnitTypeId.STARPORTTECHLAB,
-    UnitTypeId.SUPPLYDEPOT,
-    UnitTypeId.SUPPLYDEPOTLOWERED,
-    UnitTypeId.TECHLAB,
-    UnitTypeId.TEMPLARARCHIVE,
-    UnitTypeId.TWILIGHTCOUNCIL,
-    UnitTypeId.ULTRALISKCAVERN,
-    UnitTypeId.WARPGATE,
-}
+ALL_STRUCTURES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ARMORY,
+        UnitTypeId.ASSIMILATOR,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.AUTOTURRET,
+        UnitTypeId.BANELINGNEST,
+        UnitTypeId.BARRACKS,
+        UnitTypeId.BARRACKSFLYING,
+        UnitTypeId.BARRACKSREACTOR,
+        UnitTypeId.BARRACKSTECHLAB,
+        UnitTypeId.BUNKER,
+        UnitTypeId.BYPASSARMORDRONE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CYBERNETICSCORE,
+        UnitTypeId.DARKSHRINE,
+        UnitTypeId.ELSECARO_COLONIST_HUT,
+        UnitTypeId.ENGINEERINGBAY,
+        UnitTypeId.EVOLUTIONCHAMBER,
+        UnitTypeId.EXTRACTOR,
+        UnitTypeId.EXTRACTORRICH,
+        UnitTypeId.FACTORY,
+        UnitTypeId.FACTORYFLYING,
+        UnitTypeId.FACTORYREACTOR,
+        UnitTypeId.FACTORYTECHLAB,
+        UnitTypeId.FLEETBEACON,
+        UnitTypeId.FORGE,
+        UnitTypeId.FUSIONCORE,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.GHOSTACADEMY,
+        UnitTypeId.GREATERSPIRE,
+        UnitTypeId.HATCHERY,
+        UnitTypeId.HIVE,
+        UnitTypeId.HYDRALISKDEN,
+        UnitTypeId.INFESTATIONPIT,
+        UnitTypeId.LAIR,
+        UnitTypeId.LURKERDENMP,
+        UnitTypeId.MEDIVACMENGSKACGLUESCREENDUMMY,
+        UnitTypeId.MISSILETURRET,
+        UnitTypeId.NEXUS,
+        UnitTypeId.NYDUSCANAL,
+        UnitTypeId.NYDUSCANALATTACKER,
+        UnitTypeId.NYDUSCANALCREEPER,
+        UnitTypeId.NYDUSNETWORK,
+        UnitTypeId.ORACLESTASISTRAP,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.PLANETARYFORTRESS,
+        UnitTypeId.POINTDEFENSEDRONE,
+        UnitTypeId.PYLON,
+        UnitTypeId.PYLONOVERCHARGED,
+        UnitTypeId.RAVENREPAIRDRONE,
+        UnitTypeId.REACTOR,
+        UnitTypeId.REFINERY,
+        UnitTypeId.REFINERYRICH,
+        UnitTypeId.RESOURCEBLOCKER,
+        UnitTypeId.ROACHWARREN,
+        UnitTypeId.ROBOTICSBAY,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.SENSORTOWER,
+        UnitTypeId.SHIELDBATTERY,
+        UnitTypeId.SIEGETANKMENGSKACGLUESCREENDUMMY,
+        UnitTypeId.SPAWNINGPOOL,
+        UnitTypeId.SPINECRAWLER,
+        UnitTypeId.SPINECRAWLERUPROOTED,
+        UnitTypeId.SPIRE,
+        UnitTypeId.SPORECRAWLER,
+        UnitTypeId.SPORECRAWLERUPROOTED,
+        UnitTypeId.STARGATE,
+        UnitTypeId.STARPORT,
+        UnitTypeId.STARPORTFLYING,
+        UnitTypeId.STARPORTREACTOR,
+        UnitTypeId.STARPORTTECHLAB,
+        UnitTypeId.SUPPLYDEPOT,
+        UnitTypeId.SUPPLYDEPOTLOWERED,
+        UnitTypeId.TECHLAB,
+        UnitTypeId.TEMPLARARCHIVE,
+        UnitTypeId.TWILIGHTCOUNCIL,
+        UnitTypeId.ULTRALISKCAVERN,
+        UnitTypeId.WARPGATE,
+    }
+)
 
-BURROWED_ALIAS: frozenset[UnitTypeId] = {
-    UnitTypeId.BANELINGBURROWED,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.DRONEBURROWED,
-    UnitTypeId.HYDRALISKBURROWED,
-    UnitTypeId.INFESTORBURROWED,
-    UnitTypeId.INFESTORTERRANBURROWED,
-    UnitTypeId.LURKERMPBURROWED,
-    UnitTypeId.QUEENBURROWED,
-    UnitTypeId.RAVAGERBURROWED,
-    UnitTypeId.ROACHBURROWED,
-    UnitTypeId.SWARMHOSTBURROWEDMP,
-    UnitTypeId.ULTRALISKBURROWED,
-    UnitTypeId.WIDOWMINEBURROWED,
-    UnitTypeId.ZERGLINGBURROWED,
-}
+BURROWED_ALIAS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BANELINGBURROWED,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.DRONEBURROWED,
+        UnitTypeId.HYDRALISKBURROWED,
+        UnitTypeId.INFESTORBURROWED,
+        UnitTypeId.INFESTORTERRANBURROWED,
+        UnitTypeId.LURKERMPBURROWED,
+        UnitTypeId.QUEENBURROWED,
+        UnitTypeId.RAVAGERBURROWED,
+        UnitTypeId.ROACHBURROWED,
+        UnitTypeId.SWARMHOSTBURROWEDMP,
+        UnitTypeId.ULTRALISKBURROWED,
+        UnitTypeId.WIDOWMINEBURROWED,
+        UnitTypeId.ZERGLINGBURROWED,
+    }
+)
 
-CHANGELING_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.CHANGELING,
-    UnitTypeId.CHANGELINGZERGLING,
-    UnitTypeId.CHANGELINGZERGLINGWINGS,
-    UnitTypeId.CHANGELINGMARINE,
-    UnitTypeId.CHANGELINGMARINESHIELD,
-    UnitTypeId.CHANGELINGZEALOT,
-}
+CHANGELING_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.CHANGELING,
+        UnitTypeId.CHANGELINGZERGLING,
+        UnitTypeId.CHANGELINGZERGLINGWINGS,
+        UnitTypeId.CHANGELINGMARINE,
+        UnitTypeId.CHANGELINGMARINESHIELD,
+        UnitTypeId.CHANGELINGZEALOT,
+    }
+)
 
-COMMON_UNIT_IGNORE_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.EGG,
-    UnitTypeId.LARVA,
-    UnitTypeId.CREEPTUMORBURROWED,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.MULE,
-}
+COMMON_UNIT_IGNORE_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.EGG,
+        UnitTypeId.LARVA,
+        UnitTypeId.CREEPTUMORBURROWED,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.MULE,
+    }
+)
 
-CREEP_TUMOR_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.CREEPTUMOR,
-    UnitTypeId.CREEPTUMORQUEEN,
-    UnitTypeId.CREEPTUMORBURROWED,
-}
+CREEP_TUMOR_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.CREEPTUMOR,
+        UnitTypeId.CREEPTUMORQUEEN,
+        UnitTypeId.CREEPTUMORBURROWED,
+    }
+)
 
-DETECTORS: frozenset[UnitTypeId | EffectId] = {
-    UnitTypeId.OBSERVER,
-    UnitTypeId.OBSERVERSIEGEMODE,
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.RAVEN,
-    UnitTypeId.MISSILETURRET,
-    EffectId.SCANNERSWEEP,
-    UnitTypeId.OVERSEER,
-    UnitTypeId.OVERSEERSIEGEMODE,
-    UnitTypeId.SPORECRAWLER,
-}
+DETECTORS: frozenset[UnitTypeId | EffectId] = frozenset(
+    {
+        UnitTypeId.OBSERVER,
+        UnitTypeId.OBSERVERSIEGEMODE,
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.RAVEN,
+        UnitTypeId.MISSILETURRET,
+        EffectId.SCANNERSWEEP,
+        UnitTypeId.OVERSEER,
+        UnitTypeId.OVERSEERSIEGEMODE,
+        UnitTypeId.SPORECRAWLER,
+    }
+)
 
-DROP_ROLES: frozenset[UnitRole] = {
-    UnitRole.DROP_SHIP,
-    UnitRole.DROP_UNITS_TO_LOAD,
-    UnitRole.DROP_UNITS_ATTACKING,
-}
+DROP_ROLES: frozenset[UnitRole] = frozenset(
+    {
+        UnitRole.DROP_SHIP,
+        UnitRole.DROP_UNITS_TO_LOAD,
+        UnitRole.DROP_UNITS_ATTACKING,
+    }
+)
 
-EGG_BUTTON_NAMES: frozenset[str] = {"Drone", "Overlord"}
+EGG_BUTTON_NAMES: frozenset[str] = frozenset({"Drone", "Overlord"})
 
 # we ignore these when detecting if an expansion location is blocked
-FLYING_IGNORE: frozenset[UnitTypeId] = {
-    UnitTypeId.OBSERVER,
-    UnitTypeId.OVERLORD,
-    UnitTypeId.OVERSEER,
-    UnitTypeId.BARRACKSFLYING,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.FACTORYFLYING,
-    UnitTypeId.STARPORTFLYING,
-    UnitTypeId.PHOENIX,
-}
+FLYING_IGNORE: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.OBSERVER,
+        UnitTypeId.OVERLORD,
+        UnitTypeId.OVERSEER,
+        UnitTypeId.BARRACKSFLYING,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.FACTORYFLYING,
+        UnitTypeId.STARPORTFLYING,
+        UnitTypeId.PHOENIX,
+    }
+)
 
-GAS_BUILDINGS: frozenset[UnitTypeId] = {
-    UnitTypeId.ASSIMILATOR,
-    UnitTypeId.EXTRACTOR,
-    UnitTypeId.REFINERY,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.EXTRACTORRICH,
-    UnitTypeId.REFINERYRICH,
-}
+GAS_BUILDINGS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ASSIMILATOR,
+        UnitTypeId.EXTRACTOR,
+        UnitTypeId.REFINERY,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.EXTRACTORRICH,
+        UnitTypeId.REFINERYRICH,
+    }
+)
 
-GATEWAY_UNITS: frozenset[UnitTypeId] = {
-    UnitTypeId.ZEALOT,
-    UnitTypeId.ADEPT,
-    UnitTypeId.STALKER,
-    UnitTypeId.DARKTEMPLAR,
-    UnitTypeId.HIGHTEMPLAR,
-    UnitTypeId.SENTRY,
-}
+GATEWAY_UNITS: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.ZEALOT,
+        UnitTypeId.ADEPT,
+        UnitTypeId.STALKER,
+        UnitTypeId.DARKTEMPLAR,
+        UnitTypeId.HIGHTEMPLAR,
+        UnitTypeId.SENTRY,
+    }
+)
 
 # These are not really rocks, but end up in the destructible collection
 IGNORE_DESTRUCTABLES: set[UnitTypeId] = {
@@ -796,21 +836,23 @@ IGNORE_DESTRUCTABLES: set[UnitTypeId] = {
     UnitTypeId.CLEANINGBOT,
 }
 
-IGNORE_IN_COST_DICT: frozenset[UnitTypeId] = {
-    UnitTypeId.BROODLING,
-    UnitTypeId.INTERCEPTOR,
-    UnitTypeId.LARVA,
-    UnitTypeId.LOCUSTMP,
-    UnitTypeId.LOCUSTMPFLYING,
-    UnitTypeId.MULE,
-    UnitTypeId.POINTDEFENSEDRONE,
-    UnitTypeId.INFESTEDTERRANSEGG,
-    UnitTypeId.INFESTEDTERRAN,
-    UnitTypeId.INFESTORBURROWED,
-    UnitTypeId.REFINERYRICH,
-    UnitTypeId.ASSIMILATORRICH,
-    UnitTypeId.EXTRACTORRICH,
-}
+IGNORE_IN_COST_DICT: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.BROODLING,
+        UnitTypeId.INTERCEPTOR,
+        UnitTypeId.LARVA,
+        UnitTypeId.LOCUSTMP,
+        UnitTypeId.LOCUSTMPFLYING,
+        UnitTypeId.MULE,
+        UnitTypeId.POINTDEFENSEDRONE,
+        UnitTypeId.INFESTEDTERRANSEGG,
+        UnitTypeId.INFESTEDTERRAN,
+        UnitTypeId.INFESTORBURROWED,
+        UnitTypeId.REFINERYRICH,
+        UnitTypeId.ASSIMILATORRICH,
+        UnitTypeId.EXTRACTORRICH,
+    }
+)
 
 IGNORED_UNIT_TYPES_MEMORY_MANAGER: set[UnitTypeId] = set()
 
@@ -820,35 +862,33 @@ MAIN_COMBAT_ROLES: set[UnitRole] = {
     UnitRole.DEFENDING,
 }
 
-TECHLAB_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.BARRACKSTECHLAB,
-    UnitTypeId.FACTORYTECHLAB,
-    UnitTypeId.STARPORTTECHLAB,
-    UnitTypeId.TECHLAB,
-}
 
-TOWNHALL_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.HATCHERY,
-    UnitTypeId.LAIR,
-    UnitTypeId.HIVE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.PLANETARYFORTRESS,
-    UnitTypeId.NEXUS,
-}
+TOWNHALL_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.HATCHERY,
+        UnitTypeId.LAIR,
+        UnitTypeId.HIVE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.PLANETARYFORTRESS,
+        UnitTypeId.NEXUS,
+    }
+)
 
-TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = {
-    UnitTypeId.HATCHERY,
-    UnitTypeId.LAIR,
-    UnitTypeId.HIVE,
-    UnitTypeId.COMMANDCENTER,
-    UnitTypeId.COMMANDCENTERFLYING,
-    UnitTypeId.ORBITALCOMMAND,
-    UnitTypeId.ORBITALCOMMANDFLYING,
-    UnitTypeId.NEXUS,
-}
+TOWNHALL_TYPES_NO_PF: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.HATCHERY,
+        UnitTypeId.LAIR,
+        UnitTypeId.HIVE,
+        UnitTypeId.COMMANDCENTER,
+        UnitTypeId.COMMANDCENTERFLYING,
+        UnitTypeId.ORBITALCOMMAND,
+        UnitTypeId.ORBITALCOMMANDFLYING,
+        UnitTypeId.NEXUS,
+    }
+)
 
 UNITS_TO_AVOID_TYPES: set[UnitTypeId] = {
     UnitTypeId.CREEPTUMOR,
@@ -863,19 +903,23 @@ UNITS_TO_AVOID_TYPES: set[UnitTypeId] = {
 UNITS_TO_IGNORE: set[UnitTypeId] = set()
 UNIT_TYPES_WITH_NO_ROLE: set[UnitTypeId] = set()
 
-WORKER_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.DRONE,
-    UnitTypeId.PROBE,
-    UnitTypeId.SCV,
-}
+WORKER_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.DRONE,
+        UnitTypeId.PROBE,
+        UnitTypeId.SCV,
+    }
+)
 
-ALL_WORKER_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.DRONE,
-    UnitTypeId.PROBE,
-    UnitTypeId.SCV,
-    UnitTypeId.DRONEBURROWED,
-    UnitTypeId.MULE,
-}
+ALL_WORKER_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.DRONE,
+        UnitTypeId.PROBE,
+        UnitTypeId.SCV,
+        UnitTypeId.DRONEBURROWED,
+        UnitTypeId.MULE,
+    }
+)
 
 RACE_SUPPLY: dict[Race.ValueType, UnitTypeId] = {
     Race.Protoss: UnitTypeId.PYLON,
@@ -883,21 +927,23 @@ RACE_SUPPLY: dict[Race.ValueType, UnitTypeId] = {
     Race.Zerg: UnitTypeId.OVERLORD,
 }
 
-REQUIRE_POWER_STRUCTURE_TYPES: frozenset[UnitTypeId] = {
-    UnitTypeId.PHOTONCANNON,
-    UnitTypeId.SHIELDBATTERY,
-    UnitTypeId.GATEWAY,
-    UnitTypeId.WARPGATE,
-    UnitTypeId.ROBOTICSFACILITY,
-    UnitTypeId.ROBOTICSBAY,
-    UnitTypeId.STARGATE,
-    UnitTypeId.CYBERNETICSCORE,
-    UnitTypeId.FORGE,
-    UnitTypeId.TEMPLARARCHIVE,
-    UnitTypeId.FLEETBEACON,
-    UnitTypeId.TWILIGHTCOUNCIL,
-    UnitTypeId.DARKSHRINE,
-}
+REQUIRE_POWER_STRUCTURE_TYPES: frozenset[UnitTypeId] = frozenset(
+    {
+        UnitTypeId.PHOTONCANNON,
+        UnitTypeId.SHIELDBATTERY,
+        UnitTypeId.GATEWAY,
+        UnitTypeId.WARPGATE,
+        UnitTypeId.ROBOTICSFACILITY,
+        UnitTypeId.ROBOTICSBAY,
+        UnitTypeId.STARGATE,
+        UnitTypeId.CYBERNETICSCORE,
+        UnitTypeId.FORGE,
+        UnitTypeId.TEMPLARARCHIVE,
+        UnitTypeId.FLEETBEACON,
+        UnitTypeId.TWILIGHTCOUNCIL,
+        UnitTypeId.DARKSHRINE,
+    }
+)
 
 LOSS_EMPHATIC_OR_WORSE: set[EngagementResult] = {EngagementResult.LOSS_EMPHATIC}
 

--- a/src/ares/custom_bot_ai.py
+++ b/src/ares/custom_bot_ai.py
@@ -1,5 +1,7 @@
 """Extension of sc2.BotAI to add custom functions."""
 
+from __future__ import annotations
+
 import argparse
 
 import numpy as np

--- a/src/ares/dicts/ability_cooldowns.py
+++ b/src/ares/dicts/ability_cooldowns.py
@@ -1,5 +1,7 @@
 """Ability base cooldowns."""
 
+from __future__ import annotations
+
 from sc2.ids.ability_id import AbilityId
 
 # in frames

--- a/src/ares/dicts/aoe_ability_to_range.py
+++ b/src/ares/dicts/aoe_ability_to_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.ability_id import AbilityId
 from sc2.ids.buff_id import BuffId
 from sc2.ids.effect_id import EffectId

--- a/src/ares/dicts/cost_dict.py
+++ b/src/ares/dicts/cost_dict.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.game_data import Cost
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/does_not_use_larva.py
+++ b/src/ares/dicts/does_not_use_larva.py
@@ -1,5 +1,7 @@
 """Zerg units that do not use Larva."""
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # key is the unit to build, value is the unit it builds from

--- a/src/ares/dicts/enemy_detector_ranges.py
+++ b/src/ares/dicts/enemy_detector_ranges.py
@@ -5,6 +5,8 @@ detectors will not be in range if they use these values.
 
 """
 
+from __future__ import annotations
+
 from sc2.ids.effect_id import EffectId
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/pickup_range.py
+++ b/src/ares/dicts/pickup_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # TODO: Correct these

--- a/src/ares/dicts/structure_to_building_size.py
+++ b/src/ares/dicts/structure_to_building_size.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 from ares.consts import BuildingSize

--- a/src/ares/dicts/turn_rate.py
+++ b/src/ares/dicts/turn_rate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from sc2.ids.unit_typeid import UnitTypeId
 

--- a/src/ares/dicts/unit_alias.py
+++ b/src/ares/dicts/unit_alias.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # similar to python-sc2 version, but with modifications for use in

--- a/src/ares/dicts/unit_data.py
+++ b/src/ares/dicts/unit_data.py
@@ -1,5 +1,7 @@
 """Mineral, gas, supply, and army values for units."""
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # army_value = (((minerals / 0.9) + gas) * supply) / 50

--- a/src/ares/dicts/unit_tech_requirement.py
+++ b/src/ares/dicts/unit_tech_requirement.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 UNIT_TECH_REQUIREMENT: dict[UnitTypeId, list[UnitTypeId]] = dict(

--- a/src/ares/dicts/weight_costs.py
+++ b/src/ares/dicts/weight_costs.py
@@ -5,6 +5,8 @@ values are taken from the API for some units.
 
 """
 
+from __future__ import annotations
+
 from sc2.ids.unit_typeid import UnitTypeId
 
 # Zerg building data includes Drone cost

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections import defaultdict
 from os import getcwd, path

--- a/src/ares/managers/ability_tracker_manager.py
+++ b/src/ares/managers/ability_tracker_manager.py
@@ -1,5 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.ids.ability_id import AbilityId
@@ -29,7 +31,7 @@ class AbilityTrackerManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -71,7 +73,7 @@ class AbilityTrackerManager(Manager, IManagerMediator):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 

--- a/src/ares/managers/building_manager.py
+++ b/src/ares/managers/building_manager.py
@@ -1,5 +1,7 @@
 """Handle the construction of buildings."""
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 
@@ -65,7 +67,7 @@ class BuildingManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -73,16 +75,12 @@ class BuildingManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(BuildingManager, self).__init__(ai, config, mediator)
 
@@ -144,10 +142,6 @@ class BuildingManager(Manager, IManagerMediator):
         ----------
         iteration :
             The current game iteration.
-
-        Returns
-        -------
-
         """
         self._handle_construction_orders()
 
@@ -604,8 +598,8 @@ class BuildingManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        building
-        pos
+        building : UnitTypeId
+        pos : Point2
 
         Returns
         -------

--- a/src/ares/managers/combat_sim_manager.py
+++ b/src/ares/managers/combat_sim_manager.py
@@ -13,6 +13,8 @@ WARNING:
     - IDPTG/Paul
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from sc2.units import Units
@@ -29,7 +31,7 @@ if TYPE_CHECKING:
 class CombatSimManager(Manager, IManagerMediator):
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -37,11 +39,11 @@ class CombatSimManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(CombatSimManager, self).__init__(ai, config, mediator)

--- a/src/ares/managers/creep_manager.py
+++ b/src/ares/managers/creep_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 from typing import Any
 
@@ -482,13 +484,15 @@ class CreepManager(Manager, IManagerMediator):
         This function finds the edge of creep and distributes
         overlord positions evenly around it.
 
-        Parameters:
-            overlords : Units | list[Unit]
-                The overlords that will be positioned for creep vision
+        Parameters
+        ----------
+        overlords : list[Unit] | Units
+            The overlords that will be positioned for creep vision.
 
-        Returns:
-            dict[int: Point2]
-                Dictionary mapping overlord tag to position where it should move
+        Returns
+        -------
+        dict[int: Point2]
+            Dictionary mapping overlord tag to position where it should move.
         """
         if not overlords:
             return {}

--- a/src/ares/managers/data_manager.py
+++ b/src/ares/managers/data_manager.py
@@ -1,5 +1,7 @@
 """Handle data."""
 
+from __future__ import annotations
+
 import json
 import os
 from collections import defaultdict, deque

--- a/src/ares/managers/enemy_to_base_manager.py
+++ b/src/ares/managers/enemy_to_base_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from enum import Enum, auto
 
@@ -46,11 +48,11 @@ class EnemyToBaseManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(EnemyToBaseManager, self).__init__(ai, config, mediator)
@@ -112,11 +114,11 @@ class EnemyToBaseManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        receiver :
+        receiver : ManagerName
             This Manager.
-        request :
+        request : ManagerRequestType
             What kind of request is being made
-        reason :
+        reason : str = None
             Why the reason is being made
         kwargs :
             Additional keyword args if needed for the specific request, as determined
@@ -126,7 +128,6 @@ class EnemyToBaseManager(Manager, IManagerMediator):
         -------
         int | dict | Units :
             Types that can be returned from mediator requests via this manager.
-
         """
         return self.manager_requests_dict[request](kwargs)
 

--- a/src/ares/managers/flying_structure_manager.py
+++ b/src/ares/managers/flying_structure_manager.py
@@ -1,5 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from cython_extensions import cy_distance_to_squared
@@ -25,7 +27,7 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -33,11 +35,11 @@ class FlyingStructureManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
 
         Returns
@@ -65,17 +67,17 @@ class FlyingStructureManager(Manager, IManagerMediator):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> dict | None:
         """Fetch information from this Manager so another Manager can use it.
 
         Parameters
         ----------
-        receiver :
+        receiver : ManagerName
             This Manager.
-        request :
+        request : ManagerRequestType
             What kind of request is being made
-        reason :
+        reason : str = None
             Why the reason is being made
         kwargs :
             Additional keyword args if needed for the specific request, as determined

--- a/src/ares/managers/grid_manager.py
+++ b/src/ares/managers/grid_manager.py
@@ -110,7 +110,7 @@ class GridManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:

--- a/src/ares/managers/hub.py
+++ b/src/ares/managers/hub.py
@@ -1,5 +1,7 @@
 """The core of the bot."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.data import Race, Result
@@ -41,7 +43,7 @@ class Hub:
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         manager_mediator: ManagerMediator,
         data_manager: DataManager = None,
@@ -94,7 +96,7 @@ class Hub:
             Additional custom managers
 
         """
-        self.ai: "AresBot" = ai
+        self.ai: AresBot = ai
         self.debug: bool = config[DEBUG]
         self.config: dict = config
         self.manager_mediator: ManagerMediator = manager_mediator

--- a/src/ares/managers/intel_manager.py
+++ b/src/ares/managers/intel_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from cython_extensions import cy_distance_to_squared
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
 class IntelManager(Manager, IManagerMediator):
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -130,7 +132,6 @@ class IntelManager(Manager, IManagerMediator):
         -------
         Optional[Union[Dict, DefaultDict, Coroutine[Any, Any, bool]]] :
             Everything that could possibly be returned from the Manager fits in there
-
         """
         if self.ai.arcade_mode:
             logger.warning(

--- a/src/ares/managers/manager.py
+++ b/src/ares/managers/manager.py
@@ -1,5 +1,7 @@
 """Base class for Managers."""
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +30,7 @@ class Manager(metaclass=ABCMeta):
 
     """
 
-    def __init__(self, ai: "AresBot", config: dict, mediator: ManagerMediator) -> None:
+    def __init__(self, ai: AresBot, config: dict, mediator: ManagerMediator) -> None:
         """Set up the manager.
 
         Parameters
@@ -64,7 +66,7 @@ class Manager(metaclass=ABCMeta):
         receiver: ManagerName,
         request: ManagerRequestType,
         reason: str = None,
-        **kwargs
+        **kwargs,
     ) -> Any:
         """To be implemented by managers that inherit from IManagerMediator interface.
 

--- a/src/ares/managers/manager_mediator.py
+++ b/src/ares/managers/manager_mediator.py
@@ -28,7 +28,7 @@ class IManagerMediator(metaclass=ABCMeta):
     pass the execution to other components (managers).
     """
 
-    # each manager has a `dict` linking the request type to a callable action
+    # each manager has a dict linking the request type to a callable action
     manager_requests_dict: dict[ManagerRequestType, Callable]
 
     @abstractmethod
@@ -297,7 +297,7 @@ class ManagerMediator(IManagerMediator):
         )
 
     def get_closest_creep_tile(self, **kwargs) -> None | Point2:
-        """Get closest creep tile to `pos`
+        """Get the closest creep tile to pos
 
         WARNING: May return `None` if no creep tiles observed.
 

--- a/src/ares/managers/nydus_manager.py
+++ b/src/ares/managers/nydus_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict, deque
 from typing import TYPE_CHECKING, Any
 
@@ -33,7 +35,7 @@ class NydusManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -41,11 +43,11 @@ class NydusManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super().__init__(ai, config, mediator)

--- a/src/ares/managers/path_manager.py
+++ b/src/ares/managers/path_manager.py
@@ -4,6 +4,8 @@ This manager handles path finding and coordinates with GridManager for grid-rela
 operations.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -39,7 +41,7 @@ class PathManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -47,11 +49,11 @@ class PathManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super().__init__(ai, config, mediator)
@@ -246,25 +248,25 @@ class PathManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        start :
+        start : Point2
             Start point of the path.
-        target :
+        target : Point2
             Desired end point of the path.
-        grid :
+        grid : np.ndarray
             The grid that should be used for pathing.
-        sensitivity :
+        sensitivity : int = 5
             Amount of points that should be skipped in the full path between tiles that
             are returned.
-        smoothing :
+        smoothing : bool = False
             Optional path smoothing where nodes are removed if it's possible to jump
             ahead some tiles in a straight line with a lower cost.
-        sense_danger :
+        sense_danger : bool = False
             Check to see if there are any dangerous tiles near the starting point. If
             this is True and there are no dangerous tiles near the starting point, the
             pathing query is skipped and the target is returned.
-        danger_distance :
+        danger_distance : int = 20.0,
             How far away from the start to look for danger.
-        danger_threshold :
+        danger_threshold : float = 5.0
             Minimum value for a tile to be considered dangerous.
 
         Returns
@@ -367,8 +369,8 @@ class PathManager(Manager, IManagerMediator):
 
         Returns
         -------
-        List[Point2] :
-            List of points composing the path
+        list[Point2] :
+            `list` of points composing the path
         """
         return self.map_data.pathfind(start, target, grid, sensitivity=sensitivity)
 

--- a/src/ares/managers/placement_manager.py
+++ b/src/ares/managers/placement_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import time
 from collections import defaultdict
@@ -87,7 +89,7 @@ class PlacementManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -95,11 +97,11 @@ class PlacementManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(PlacementManager, self).__init__(ai, config, mediator)
@@ -1278,7 +1280,9 @@ class PlacementManager(Manager, IManagerMediator):
         The pylon position
         """
         pylon_pos: Point2 = self.ai.main_base_ramp.protoss_wall_pylon
-        buildings: frozenset[Point2] = self.ai.main_base_ramp.protoss_wall_buildings
+        buildings: frozenset[Point2] = frozenset(
+            self.ai.main_base_ramp.protoss_wall_buildings
+        )
 
         self._add_placement_position(
             BuildingSize.TWO_BY_TWO, el, pylon_pos, wall=True, production_pylon=True

--- a/src/ares/managers/resource_manager.py
+++ b/src/ares/managers/resource_manager.py
@@ -1,5 +1,7 @@
 """Anything to do with resource management and collection."""
 
+from __future__ import annotations
+
 import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
@@ -43,7 +45,7 @@ class ResourceManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -51,16 +53,12 @@ class ResourceManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(ResourceManager, self).__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -128,11 +126,7 @@ class ResourceManager(Manager, IManagerMediator):
         self.initial_worker_split: bool = True
 
     def set_worker_per_gas(self, amount: int) -> None:
-        """Sets how many workers to be assigned to each gas building
-
-        Returns
-        -------
-        """
+        """Sets how many workers to be assigned to each gas building"""
         self.workers_per_gas = amount
 
     @property_cache_once_per_frame

--- a/src/ares/managers/squad_manager.py
+++ b/src/ares/managers/squad_manager.py
@@ -1,5 +1,7 @@
 """Handle manual tracking of abilities until python-sc2 PR #163 is merged."""
 
+from __future__ import annotations
+
 import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -81,7 +83,7 @@ class SquadManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -89,16 +91,12 @@ class SquadManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {

--- a/src/ares/managers/terrain_manager.py
+++ b/src/ares/managers/terrain_manager.py
@@ -1,5 +1,7 @@
 """Calculations involving terrain."""
 
+from __future__ import annotations
+
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -53,24 +55,20 @@ class TerrainManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
-        """Set up the manager.
+        """Sets up the manager.
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {
@@ -407,15 +405,15 @@ class TerrainManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        start_point :
+        start_point : Point2
             Start flood fill outwards from this point.
-        max_dist :
+        max_dist : int = 25
             Distance from start point before finishing the algorithm.
 
         Returns
         -------
         set :
-            Set of points (as tuples) that are filled in
+            `set` of points (as `tuples`) that are filled in.
         """
         all_points = cy_flood_fill_grid(
             start_point=start_point.rounded,

--- a/src/ares/managers/unit_cache_manager.py
+++ b/src/ares/managers/unit_cache_manager.py
@@ -1,5 +1,7 @@
 """Cache armies for better and faster tracking."""
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -37,7 +39,7 @@ class UnitCacheManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -45,16 +47,12 @@ class UnitCacheManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super().__init__(ai, config, mediator)
         self.manager_requests_dict = {

--- a/src/ares/managers/unit_memory_manager.py
+++ b/src/ares/managers/unit_memory_manager.py
@@ -1,5 +1,7 @@
 """Manager for keeping track of enemy last known positions."""
 
+from __future__ import annotations
+
 from collections import deque
 from typing import TYPE_CHECKING, Any, Deque
 
@@ -37,7 +39,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -613,7 +615,7 @@ class UnitMemoryManager(Manager, IManagerMediator):
 
         Returns
         -------
-        Set[int] :
+        unit_tags_in_range_list : set[int]
             Set of tags of our units that are in range of a detector. This doesn't take
             our unit's radius into account, only the radius of the detector.
         """

--- a/src/ares/managers/unit_role_manager.py
+++ b/src/ares/managers/unit_role_manager.py
@@ -1,5 +1,7 @@
 """Manage assigning/removing of roles and getting units by role."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from sc2.ids.unit_typeid import UnitTypeId
@@ -35,7 +37,7 @@ class UnitRoleManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -43,16 +45,12 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
-
-        Returns
-        -------
-
         """
         super(UnitRoleManager, self).__init__(ai, config, mediator)
         self.unit_role_dict: dict[str, set[int]] = {
@@ -203,14 +201,10 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        tags :
+        tags : list[int] | set[int]
             Tags of the units to assign to a role.
-        role :
+        role : UnitRole
             The role the units should be assigned to.
-
-        Returns
-        -------
-
         """
         for tag in tags:
             self.assign_role(tag, role)
@@ -240,12 +234,8 @@ class UnitRoleManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        tags :
+        tags : set[int]
             Tags of the units to clear the roles of.
-
-        Returns
-        -------
-
         """
         for tag in tags:
             self.clear_role(tag)

--- a/src/ares/managers/utils/placement_strategy.py
+++ b/src/ares/managers/utils/placement_strategy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 

--- a/src/ares/managers/utils/user_placement_extractor.py
+++ b/src/ares/managers/utils/user_placement_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sc2.data import Race
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 class UserPlacementExtractor:
     """Handles extraction and parsing of user-defined building placements from YAML."""
 
-    def __init__(self, ai: "AresBot", user_placements: dict):
+    def __init__(self, ai: AresBot, user_placements: dict):
         self.ai = ai
         self.user_placements = user_placements
 

--- a/src/ares/managers/warp_in_manager.py
+++ b/src/ares/managers/warp_in_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Coroutine
 
@@ -21,7 +23,7 @@ class WarpInManager(Manager, IManagerMediator):
 
     def __init__(
         self,
-        ai: "AresBot",
+        ai: AresBot,
         config: dict,
         mediator: ManagerMediator,
     ) -> None:
@@ -29,11 +31,11 @@ class WarpInManager(Manager, IManagerMediator):
 
         Parameters
         ----------
-        ai :
+        ai : AresBot
             Bot object that will be running the game
-        config :
+        config : dict
             Dictionary with the data from the configuration file
-        mediator :
+        mediator : ManagerMediator
             ManagerMediator used for getting information from other managers.
         """
         super(WarpInManager, self).__init__(ai, config, mediator)

--- a/tests/behaviors/combat/group/test_stutter_group_back.py
+++ b/tests/behaviors/combat/group/test_stutter_group_back.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_a_move.py
+++ b/tests/behaviors/combat/individual/test_a_move.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_attack_target.py
+++ b/tests/behaviors/combat/individual/test_attack_target.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/individual/test_keep_unit_safe.py
+++ b/tests/behaviors/combat/individual/test_keep_unit_safe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/combat/individual/test_shoot_target_in_range.py
+++ b/tests/behaviors/combat/individual/test_shoot_target_in_range.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/behaviors/combat/test_combat_maneuver.py
+++ b/tests/behaviors/combat/test_combat_maneuver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/behaviors/macro/test_auto_supply.py
+++ b/tests/behaviors/macro/test_auto_supply.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sys
 from os.path import abspath, dirname, join

--- a/tests/generate_pickle_data.py
+++ b/tests/generate_pickle_data.py
@@ -4,6 +4,8 @@ Thanks to burny's `python-sc2` where most of this logic was taken from.
 TODO: Make this pickle `ares` specific stuff (manager hub?) so we can run tests.
 """
 
+from __future__ import annotations
+
 import lzma
 import os
 import pickle

--- a/tests/load_bot_from_pickle.py
+++ b/tests/load_bot_from_pickle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import importlib
 import lzma

--- a/tests/managers/test_ability_tracker_manager.py
+++ b/tests/managers/test_ability_tracker_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_building_manager.py
+++ b/tests/managers/test_building_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_data_manager.py
+++ b/tests/managers/test_data_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_grid_manager.py
+++ b/tests/managers/test_grid_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/managers/test_intel_manager.py
+++ b/tests/managers/test_intel_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_placement_manager.py
+++ b/tests/managers/test_placement_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_resource_manager.py
+++ b/tests/managers/test_resource_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/managers/test_unit_role_manager.py
+++ b/tests/managers/test_unit_role_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/mock_build_order.py
+++ b/tests/mock_build_order.py
@@ -1,5 +1,7 @@
 # this is how ares would read if from the yml file
 # PLEASE DON'T EDIT THIS!
+from __future__ import annotations
+
 MOCK_BUILD_ORDER: list[str] = [
     "14 supply @ ramp",
     "16 barracks @ ramp",

--- a/tests/mock_config.py
+++ b/tests/mock_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 MOCK_CONFIG: dict = {
     "UseData": False,
     "Debug": False,

--- a/tests/test_bots/melee_bot.py
+++ b/tests/test_bots/melee_bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_bots/micro_bot.py
+++ b/tests/test_bots/micro_bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import sys
 from os.path import abspath, dirname, join

--- a/tests/test_build_runner.py
+++ b/tests/test_build_runner.py
@@ -2,6 +2,8 @@
 TODO: Work out how to test the build runner properly
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_custom_bot_ai.py
+++ b/tests/test_custom_bot_ai.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_manager_mediator.py
+++ b/tests/test_manager_mediator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,8 @@ Starts as a random race and speed mines with 12 workers.
 
 """
 
+from __future__ import annotations
+
 import random
 import sys
 from os import path

--- a/tests/travis_test_script.py
+++ b/tests/travis_test_script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 import time


### PR DESCRIPTION
Refactor(clean): Enable deferred type evaluation (from __future__ import annotations)

Benefits:
- Allows clean (no " " needed) TYPE_CHECKING imports.
- Very slightly faster bot initialization.
- Very slightly lower in-game RAM footprint by storing type hints as strings rather than objects.
- The import itself generates no overhead, more like a switch/bool.

Risks:
- In theory, if something tries to use get_type_hints() or reads raw annotations expecting actual objects, it could cause issues.

ref. [PEP 563](https://peps.python.org/pep-0563/), [PEP 649](https://peps.python.org/pep-0649/), [PEP 749](https://peps.python.org/pep-0749/)